### PR TITLE
[feat/#21] 폴더 삭제 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
+++ b/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
@@ -29,7 +29,7 @@ public class FolderController {
     @Operation(summary = "폴더 삭제 API", description = "폴더 삭제하는 API입니다.")
     @DeleteMapping("/folders/{folderId}")
     public BaseResponse<String> deleteFolder(@PathVariable Long folderId) {
-        if(folderService.folderExist(folderId)){
+        if(!folderService.folderExist(folderId)){
             return BaseResponse.onFailure(ErrorStatus.NO_SUCH_FOLDER, null);
         }
         folderService.deleteFolder(folderId);

--- a/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
+++ b/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
@@ -4,15 +4,14 @@ import com.clokey.server.domain.folder.application.FolderService;
 import com.clokey.server.domain.folder.converter.FolderConverter;
 import com.clokey.server.domain.folder.dto.FolderRequest;
 import com.clokey.server.domain.folder.dto.FolderResponse;
+import com.clokey.server.domain.folder.exception.FolderDeleteException;
 import com.clokey.server.global.common.response.BaseResponse;
+import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +24,15 @@ public class FolderController {
                                                        @RequestBody FolderRequest.FolderCreateRequest request) {
         FolderResponse.FolderIdDTO response = FolderConverter.toFolderIdDTO(folderService.createFolder(memberId, request));
         return BaseResponse.onSucesss(SuccessStatus.FOLDER_CREATED, response);
+    }
+
+    @Operation(summary = "폴더 삭제 API", description = "폴더 삭제하는 API입니다.")
+    @DeleteMapping("/folders/{folderId}")
+    public BaseResponse<String> deleteFolder(@PathVariable Long folderId) {
+        if(folderService.folderExist(folderId)){
+            return BaseResponse.onFailure(ErrorStatus.NO_SUCH_FOLDER, null);
+        }
+        folderService.deleteFolder(folderId);
+        return BaseResponse.onSucesss(SuccessStatus.FOLDER_DELETED, null);
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
+++ b/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
@@ -23,16 +23,13 @@ public class FolderController {
     public BaseResponse<FolderResponse.FolderIdDTO> createFolder(@RequestParam Long memberId,
                                                        @RequestBody FolderRequest.FolderCreateRequest request) {
         FolderResponse.FolderIdDTO response = FolderConverter.toFolderIdDTO(folderService.createFolder(memberId, request));
-        return BaseResponse.onSucesss(SuccessStatus.FOLDER_CREATED, response);
+        return BaseResponse.onSuccess(SuccessStatus.FOLDER_CREATED, response);
     }
 
     @Operation(summary = "폴더 삭제 API", description = "폴더 삭제하는 API입니다.")
     @DeleteMapping("/folders/{folderId}")
     public BaseResponse<String> deleteFolder(@PathVariable Long folderId) {
-        if(!folderService.folderExist(folderId)){
-            return BaseResponse.onFailure(ErrorStatus.NO_SUCH_FOLDER, null);
-        }
         folderService.deleteFolder(folderId);
-        return BaseResponse.onSucesss(SuccessStatus.FOLDER_DELETED, null);
+        return BaseResponse.onSuccess(SuccessStatus.FOLDER_DELETED, null);
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
+++ b/src/main/java/com/clokey/server/domain/folder/api/FolderController.java
@@ -1,0 +1,29 @@
+package com.clokey.server.domain.folder.api;
+
+import com.clokey.server.domain.folder.application.FolderService;
+import com.clokey.server.domain.folder.converter.FolderConverter;
+import com.clokey.server.domain.folder.dto.FolderRequest;
+import com.clokey.server.domain.folder.dto.FolderResponse;
+import com.clokey.server.global.common.response.BaseResponse;
+import com.clokey.server.global.error.code.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FolderController {
+    private final FolderService folderService;
+
+    @Operation(summary = "폴더 생성 API", description = "폴더 생성하는 API입니다.")
+    @PostMapping("/folders")
+    public BaseResponse<FolderResponse.FolderIdDTO> createFolder(@RequestParam Long memberId,
+                                                       @RequestBody FolderRequest.FolderCreateRequest request) {
+        FolderResponse.FolderIdDTO response = FolderConverter.toFolderIdDTO(folderService.createFolder(memberId, request));
+        return BaseResponse.onSucesss(SuccessStatus.FOLDER_CREATED, response);
+    }
+}

--- a/src/main/java/com/clokey/server/domain/folder/api/FolderRestController.java
+++ b/src/main/java/com/clokey/server/domain/folder/api/FolderRestController.java
@@ -4,18 +4,15 @@ import com.clokey.server.domain.folder.application.FolderService;
 import com.clokey.server.domain.folder.converter.FolderConverter;
 import com.clokey.server.domain.folder.dto.FolderRequest;
 import com.clokey.server.domain.folder.dto.FolderResponse;
-import com.clokey.server.domain.folder.exception.FolderDeleteException;
 import com.clokey.server.global.common.response.BaseResponse;
-import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class FolderController {
+public class FolderRestController {
     private final FolderService folderService;
 
     @Operation(summary = "폴더 생성 API", description = "폴더 생성하는 API입니다.")

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryService.java
@@ -6,4 +6,5 @@ public interface FolderRepositoryService {
 
     boolean folderExist(Long folderId);
     void saveFolder(Folder folder);
+    void deleteFolder(Long folderId);
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryService.java
@@ -1,6 +1,9 @@
 package com.clokey.server.domain.folder.application;
 
+import com.clokey.server.domain.model.Folder;
+
 public interface FolderRepositoryService {
 
     boolean folderExist(Long folderId);
+    void saveFolder(Folder folder);
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
@@ -20,4 +20,9 @@ public class FolderRepositoryServiceImpl implements FolderRepositoryService{
     public void saveFolder(Folder folder) {
         folderRepository.save(folder);
     }
+
+    @Override
+    public void deleteFolder(Long folderId) {
+        folderRepository.deleteById(folderId);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
@@ -1,17 +1,23 @@
 package com.clokey.server.domain.folder.application;
 
 import com.clokey.server.domain.folder.dao.FolderRepository;
+import com.clokey.server.domain.model.Folder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class FolderRepositoryImpl implements FolderRepositoryService{
+public class FolderRepositoryServiceImpl implements FolderRepositoryService{
 
     private final FolderRepository folderRepository;
 
     @Override
     public boolean folderExist(Long folderId) {
         return folderRepository.existsById(folderId);
+    }
+
+    @Override
+    public void saveFolder(Folder folder) {
+        folderRepository.save(folder);
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderService.java
@@ -5,4 +5,6 @@ import com.clokey.server.domain.model.Folder;
 
 public interface FolderService {
     Folder createFolder(Long memberId, FolderRequest.FolderCreateRequest request);
+    void deleteFolder(Long folderId);
+    boolean folderExist(Long folderId);
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderService.java
@@ -1,0 +1,8 @@
+package com.clokey.server.domain.folder.application;
+
+import com.clokey.server.domain.folder.dto.FolderRequest;
+import com.clokey.server.domain.model.Folder;
+
+public interface FolderService {
+    Folder createFolder(Long memberId, FolderRequest.FolderCreateRequest request);
+}

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderServiceImpl.java
@@ -2,9 +2,11 @@ package com.clokey.server.domain.folder.application;
 
 import com.clokey.server.domain.folder.converter.FolderConverter;
 import com.clokey.server.domain.folder.dto.FolderRequest;
+import com.clokey.server.domain.folder.exception.FolderDeleteException;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.model.Folder;
 import com.clokey.server.domain.model.Member;
+import com.clokey.server.global.error.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -27,4 +29,19 @@ public class FolderServiceImpl implements FolderService {
         folderRepositoryService.saveFolder(newFolder);
         return newFolder;
     }
+
+    @Override
+    public void deleteFolder(Long folderId) {
+        try {
+            folderRepositoryService.deleteFolder(folderId);
+        } catch (Exception ex) {
+            throw new FolderDeleteException(ErrorStatus.FAILED_TO_DELETE_FOLDER);
+        }
+    }
+
+    @Override
+    public boolean folderExist(Long folderId) {
+        return folderRepositoryService.folderExist(folderId);
+    }
+
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderServiceImpl.java
@@ -6,6 +6,7 @@ import com.clokey.server.domain.folder.exception.FolderDeleteException;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.model.Folder;
 import com.clokey.server.domain.model.Member;
+import com.clokey.server.global.common.response.BaseResponse;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Lazy;
@@ -32,6 +33,9 @@ public class FolderServiceImpl implements FolderService {
 
     @Override
     public void deleteFolder(Long folderId) {
+        if(!folderExist(folderId)){
+            throw new FolderDeleteException(ErrorStatus.NO_SUCH_FOLDER);
+        }
         try {
             folderRepositoryService.deleteFolder(folderId);
         } catch (Exception ex) {

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderServiceImpl.java
@@ -1,0 +1,30 @@
+package com.clokey.server.domain.folder.application;
+
+import com.clokey.server.domain.folder.converter.FolderConverter;
+import com.clokey.server.domain.folder.dto.FolderRequest;
+import com.clokey.server.domain.member.application.MemberRepositoryService;
+import com.clokey.server.domain.model.Folder;
+import com.clokey.server.domain.model.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class FolderServiceImpl implements FolderService {
+
+    private final FolderRepositoryService folderRepositoryService;
+    private final MemberRepositoryService memberRepositoryService;
+
+
+    @Override
+    @Transactional
+    public Folder createFolder(Long memberId, FolderRequest.FolderCreateRequest request) {
+        Member member = memberRepositoryService.getMember(memberId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Folder newFolder = FolderConverter.toFolder(request, member);
+        folderRepositoryService.saveFolder(newFolder);
+        return newFolder;
+    }
+}

--- a/src/main/java/com/clokey/server/domain/folder/converter/FolderConverter.java
+++ b/src/main/java/com/clokey/server/domain/folder/converter/FolderConverter.java
@@ -1,0 +1,22 @@
+package com.clokey.server.domain.folder.converter;
+
+import com.clokey.server.domain.folder.dto.FolderRequest;
+import com.clokey.server.domain.folder.dto.FolderResponse;
+import com.clokey.server.domain.model.Folder;
+import com.clokey.server.domain.model.Member;
+
+
+public class FolderConverter {
+    public static Folder toFolder(FolderRequest.FolderCreateRequest request, Member member) {
+        return Folder.builder()
+                .name(request.getFolderName())
+                .member(member)
+                .build();
+    }
+
+    public static FolderResponse.FolderIdDTO toFolderIdDTO(Folder folder) {
+        return FolderResponse.FolderIdDTO.builder()
+                .folderId(folder.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/clokey/server/domain/folder/dto/FolderRequest.java
+++ b/src/main/java/com/clokey/server/domain/folder/dto/FolderRequest.java
@@ -1,0 +1,10 @@
+package com.clokey.server.domain.folder.dto;
+
+import lombok.Getter;
+
+public class FolderRequest {
+    @Getter
+    public static class FolderCreateRequest {
+        String folderName;
+    }
+}

--- a/src/main/java/com/clokey/server/domain/folder/dto/FolderResponse.java
+++ b/src/main/java/com/clokey/server/domain/folder/dto/FolderResponse.java
@@ -1,0 +1,16 @@
+package com.clokey.server.domain.folder.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FolderResponse {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FolderIdDTO {
+        private Long folderId;
+    }
+}

--- a/src/main/java/com/clokey/server/domain/folder/exception/FolderDeleteException.java
+++ b/src/main/java/com/clokey/server/domain/folder/exception/FolderDeleteException.java
@@ -1,0 +1,11 @@
+package com.clokey.server.domain.folder.exception;
+
+import com.clokey.server.global.error.code.BaseErrorCode;
+import com.clokey.server.global.error.exception.GeneralException;
+
+public class FolderDeleteException extends GeneralException {
+    public FolderDeleteException(BaseErrorCode code) {
+        super(code);
+    }
+}
+

--- a/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryService.java
@@ -1,7 +1,13 @@
 package com.clokey.server.domain.member.application;
 
+import com.clokey.server.domain.model.Member;
+
+import java.util.Optional;
+
 public interface MemberRepositoryService {
 
     boolean memberExist(Long memberId);
+
+    Optional<Member> getMember(Long memberId);
 
 }

--- a/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryServiceImpl.java
@@ -1,8 +1,11 @@
 package com.clokey.server.domain.member.application;
 
 import com.clokey.server.domain.member.dao.MemberRepository;
+import com.clokey.server.domain.model.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +17,12 @@ public class MemberRepositoryServiceImpl implements MemberRepositoryService{
     public boolean memberExist(Long memberId) {
         return memberRepository.existsById(memberId);
     }
+
+    @Override
+    public Optional<Member> getMember(Long memberId) {
+        return memberRepository.findById(memberId);
+    }
+
 }
 
 

--- a/src/main/java/com/clokey/server/global/common/response/BaseResponse.java
+++ b/src/main/java/com/clokey/server/global/common/response/BaseResponse.java
@@ -2,6 +2,7 @@ package com.clokey.server.global.common.response;
 
 import com.clokey.server.global.error.code.BaseCode;
 import com.clokey.server.global.error.code.BaseErrorCode;
+import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,7 +35,7 @@ public class BaseResponse<T> {
     public static <T> BaseResponse<T> onFailure(BaseErrorCode code, T result) {
         return new BaseResponse<>(
                 false,
-                code.getReasonHttpStatus().getCode(),
+                ErrorStatus._BAD_REQUEST.getCode(),
                 code.getReasonHttpStatus().getMessage(),
                 result);
     }

--- a/src/main/java/com/clokey/server/global/common/response/BaseResponse.java
+++ b/src/main/java/com/clokey/server/global/common/response/BaseResponse.java
@@ -24,7 +24,7 @@ public class BaseResponse<T> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T result;
 
-    public static <T> BaseResponse<T> onSucesss(BaseCode code, T result) {
+    public static <T> BaseResponse<T> onSuccess(BaseCode code, T result) {
         return new BaseResponse<>(
                 true,
                 code.getReasonHttpStatus().getCode(),
@@ -35,7 +35,7 @@ public class BaseResponse<T> {
     public static <T> BaseResponse<T> onFailure(BaseErrorCode code, T result) {
         return new BaseResponse<>(
                 false,
-                ErrorStatus._BAD_REQUEST.getCode(),
+                code.getReasonHttpStatus().getCode(),
                 code.getReasonHttpStatus().getMessage(),
                 result);
     }

--- a/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
             "/actuator/prometheus",
             "/ws/**",
             "/topic/**",
-            "**/**"
+            "/**"
     };
 
     @Bean

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -39,6 +39,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_SUCH_FOLDER(HttpStatus.BAD_REQUEST,"FOLDER_4001","존재하지 않는 폴더 ID입니다."),
     FOLDER_NAME_INVALID(HttpStatus.BAD_REQUEST,"FOLDER_4002","잘못된 폴더 이름입니다."),
     NO_SUCH_CLOTH_IN_FOLDER(HttpStatus.BAD_REQUEST,"FOLDER_4003","폴더에 존재하는 옷이 아닙니다."),
+    FAILED_TO_DELETE_FOLDER(HttpStatus.BAD_REQUEST,"FOLDER_4004","폴더 삭제에 실패했습니다."),
 
     //카테고리 에러
     NO_SUCH_CATEGORY(HttpStatus.BAD_REQUEST,"CATEGORY_4001","존재하지 않는 카테고리 ID입니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -16,18 +16,18 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     //페이징 에러
-    PAGE_INVALID(HttpStatus.BAD_REQUEST,"PAGE_4001","존재하지 않는 페이지입니다."),
+    PAGE_INVALID(HttpStatus.NOT_FOUND,"PAGE_4041","존재하지 않는 페이지입니다."),
 
     //멤버 에러
-    NO_SUCH_TERM(HttpStatus.BAD_REQUEST,"MEMBER_4001","존재하지 않는 약관ID입니다."),
+    NO_SUCH_TERM(HttpStatus.NOT_FOUND,"MEMBER_4041","존재하지 않는 약관ID입니다."),
     ESSENTIAL_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST,"MEMBER_4002","필수 약관에 동의하지 않았습니다."),
-    NO_SUCH_MEMBER(HttpStatus.BAD_REQUEST,"MEMBER_4003","존재하지 않는 멤버 ID입니다."),
+    NO_SUCH_MEMBER(HttpStatus.NOT_FOUND,"MEMBER_4043","존재하지 않는 멤버 ID입니다."),
     CLOKEY_ID_INVALID(HttpStatus.BAD_REQUEST,"MEMBER_4004","잘못된 클로키 아이디입니다."),
     DUPLICATE_CLOKEY_ID(HttpStatus.BAD_REQUEST,"MEMBER_4005","중복된 클로키 아이디입니다."),
     ESSENTIAL_INPUT_REQUIRED(HttpStatus.BAD_REQUEST,"MEMBER_4006","필수 입력 요소 값이 누락되었습니다."),
 
     //옷 에러
-    NO_SUCH_CLOTH(HttpStatus.BAD_REQUEST,"CLOTH_4001","존재하지 않는 옷 ID입니다."),
+    NO_SUCH_CLOTH(HttpStatus.NOT_FOUND,"CLOTH_4041","존재하지 않는 옷 ID입니다."),
     NO_PERMISSION_TO_ACCESS_CLOTH(HttpStatus.BAD_REQUEST,"CLOTH_4002","옷에 대한 접근 권한이 없습니다."),
     NO_PERMISSION_TO_EDIT_CLOTH(HttpStatus.BAD_REQUEST,"CLOTH_4003","옷에 대한 수정 권한이 없습니다"),
     CLOTH_VISIBILITY_INVALID(HttpStatus.BAD_REQUEST,"CLOTH_4004","잘못된 visibility 값을 입력했습니다"),
@@ -36,20 +36,20 @@ public enum ErrorStatus implements BaseErrorCode {
     CLOTH_THICKNESS_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"CLOTH_4005","옷의 두께가 범위를 벗어났습니다."),
 
     //폴더 에러
-    NO_SUCH_FOLDER(HttpStatus.BAD_REQUEST,"FOLDER_4001","존재하지 않는 폴더 ID입니다."),
+    NO_SUCH_FOLDER(HttpStatus.NOT_FOUND,"FOLDER_4041","존재하지 않는 폴더 ID입니다."),
     FOLDER_NAME_INVALID(HttpStatus.BAD_REQUEST,"FOLDER_4002","잘못된 폴더 이름입니다."),
     NO_SUCH_CLOTH_IN_FOLDER(HttpStatus.BAD_REQUEST,"FOLDER_4003","폴더에 존재하는 옷이 아닙니다."),
     FAILED_TO_DELETE_FOLDER(HttpStatus.BAD_REQUEST,"FOLDER_4004","폴더 삭제에 실패했습니다."),
 
     //카테고리 에러
-    NO_SUCH_CATEGORY(HttpStatus.BAD_REQUEST,"CATEGORY_4001","존재하지 않는 카테고리 ID입니다."),
+    NO_SUCH_CATEGORY(HttpStatus.NOT_FOUND,"CATEGORY_4041","존재하지 않는 카테고리 ID입니다."),
 
     //기록 에러
     DATE_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4001","잘못된 날짜 형식입니다."),
-    NO_SUCH_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4002","존재하지 않는 기록 ID입니다."),
+    NO_SUCH_HISTORY(HttpStatus.NOT_FOUND,"HISTORY_4042","존재하지 않는 기록 ID입니다."),
     HISTORY_VISIBILITY_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4003","잘못된 visibility 값을 입력했습니다."),
     ISLIKED_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4004","잘못된 isLiked 값을 입력했습니다."),
-    NO_SUCH_COMMENT(HttpStatus.BAD_REQUEST,"HISTORY_4005","존재하지 않는 댓글 ID입니다."),
+    NO_SUCH_COMMENT(HttpStatus.NOT_FOUND,"HISTORY_4045","존재하지 않는 댓글 ID입니다."),
 
     //알림 에러
     NOTIFICATION_TYPE_INVALID(HttpStatus.BAD_REQUEST,"NOTIFICATION_4001","잘못된 알림 Type 입니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
@@ -27,6 +27,7 @@ public enum SuccessStatus implements BaseCode {
     //폴더 성공
     FOLDER_SUCCESS(HttpStatus.OK, "FOLDER_200", "성공적으로 조회되었습니다."),
     FOLDER_CREATED(HttpStatus.CREATED, "FOLDER_201", "성공적으로 생성되었습니다."),
+    FOLDER_DELETED(HttpStatus.OK, "FOLDER_200", "성공적으로 삭제되었습니다."),
 
     //검색 성공
     SEARCH_SUCCESS(HttpStatus.OK, "SEARCH_200", "성공적으로 조회되었습니다."),


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #21 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 폴더 삭제 api 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 커스텀 예외 클래스 추가 (General Exception 이용)
- BaseResponse onFailure 수정 (400 뜨도록)
- StatusCode, ErrorCode 추가 (외적인 문제로 삭제되지 않을 시도 에러 던짐)

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/521ba136-f977-4d0b-9aa1-f63822763c79)

![image](https://github.com/user-attachments/assets/49b0a542-1398-4274-bb68-6d386f03c95d)

![image](https://github.com/user-attachments/assets/6fb2aee1-29d5-4ac6-a8a0-38c9fb00c297)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- BaseResponse 오타 수정했습니다
- ErrorCode 수정했습니다
- onFailure로 code 반영되지 않는 문제가 있어 우선 에러 처리로 구현하였습니다.