### PR TITLE
[feat/#30] 기록 좋아요 API 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryService.java
@@ -9,6 +9,4 @@ public interface MemberLikeRepositoryService {
     void deleteLike(Long memberId, Long historyId);
 
     void saveLike(Long memberId, Long historyId);
-
-    void changeLike(Long memberId, Long historyId, boolean isLiked);
 }

--- a/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryService.java
@@ -5,4 +5,10 @@ public interface MemberLikeRepositoryService {
     int countLikesOfHistory(Long historyId);
 
     boolean memberLikedHistory(Long memberId, Long historyId);
+
+    void deleteLike(Long memberId, Long historyId);
+
+    void saveLike(Long memberId, Long historyId);
+
+    void changeLike(Long memberId, Long historyId, boolean isLiked);
 }

--- a/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryServiceImpl.java
@@ -43,14 +43,4 @@ public class MemberLikeRepositoryServiceImpl implements MemberLikeRepositoryServ
         memberLikeRepository.save(memberLike);
     }
 
-    @Override
-    public void changeLike(Long memberId, Long historyId, boolean isLiked) {
-        if(isLiked) {
-            historyRepository.decrementLikes(historyId);
-            deleteLike(memberId,historyId);
-        } else {
-            historyRepository.incrementLikes(historyId);
-            saveLike(memberId,historyId);
-        }
-    }
 }

--- a/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryServiceImpl.java
@@ -1,6 +1,9 @@
 package com.clokey.server.domain.MemberLike.application;
 
 import com.clokey.server.domain.MemberLike.dao.MemberLikeRepository;
+import com.clokey.server.domain.history.application.HistoryRepositoryService;
+import com.clokey.server.domain.member.application.MemberRepositoryService;
+import com.clokey.server.domain.model.mapping.MemberLike;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,6 +12,8 @@ import org.springframework.stereotype.Service;
 public class MemberLikeRepositoryServiceImpl implements MemberLikeRepositoryService {
 
     private final MemberLikeRepository memberLikeRepository;
+    private final HistoryRepositoryService historyRepositoryService;
+    private final MemberRepositoryService memberRepositoryService;
 
     @Override
     public int countLikesOfHistory(Long historyId) {
@@ -18,5 +23,27 @@ public class MemberLikeRepositoryServiceImpl implements MemberLikeRepositoryServ
     @Override
     public boolean memberLikedHistory(Long memberId, Long historyId) {
         return memberLikeRepository.existsByMember_IdAndHistory_Id(memberId,historyId);
+    }
+
+    @Override
+    public void deleteLike(Long memberId, Long historyId) {
+        memberLikeRepository.deleteByMemberIdAndHistoryId(memberId,historyId);
+    }
+
+    @Override
+    public void saveLike(Long memberId, Long historyId) {
+        MemberLike memberLike = MemberLike.builder()
+                .history(historyRepositoryService.getHistoryById(historyId).get())
+                .member(memberRepositoryService.getMember(memberId).get())
+                .build();
+    }
+
+    @Override
+    public void changeLike(Long memberId, Long historyId, boolean isLiked) {
+        if(isLiked) {
+            deleteLike(memberId,historyId);
+            return;
+        }
+        saveLike(memberId,historyId);
     }
 }

--- a/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/MemberLike/application/MemberLikeRepositoryServiceImpl.java
@@ -2,16 +2,20 @@ package com.clokey.server.domain.MemberLike.application;
 
 import com.clokey.server.domain.MemberLike.dao.MemberLikeRepository;
 import com.clokey.server.domain.history.application.HistoryRepositoryService;
+import com.clokey.server.domain.history.dao.HistoryRepository;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.model.mapping.MemberLike;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberLikeRepositoryServiceImpl implements MemberLikeRepositoryService {
 
     private final MemberLikeRepository memberLikeRepository;
+    private final HistoryRepository historyRepository;
     private final HistoryRepositoryService historyRepositoryService;
     private final MemberRepositoryService memberRepositoryService;
 
@@ -27,7 +31,7 @@ public class MemberLikeRepositoryServiceImpl implements MemberLikeRepositoryServ
 
     @Override
     public void deleteLike(Long memberId, Long historyId) {
-        memberLikeRepository.deleteByMemberIdAndHistoryId(memberId,historyId);
+        memberLikeRepository.deleteByMember_IdAndHistory_Id(memberId,historyId);
     }
 
     @Override
@@ -36,14 +40,17 @@ public class MemberLikeRepositoryServiceImpl implements MemberLikeRepositoryServ
                 .history(historyRepositoryService.getHistoryById(historyId).get())
                 .member(memberRepositoryService.getMember(memberId).get())
                 .build();
+        memberLikeRepository.save(memberLike);
     }
 
     @Override
     public void changeLike(Long memberId, Long historyId, boolean isLiked) {
         if(isLiked) {
+            historyRepository.decrementLikes(historyId);
             deleteLike(memberId,historyId);
-            return;
+        } else {
+            historyRepository.incrementLikes(historyId);
+            saveLike(memberId,historyId);
         }
-        saveLike(memberId,historyId);
     }
 }

--- a/src/main/java/com/clokey/server/domain/MemberLike/dao/MemberLikeRepository.java
+++ b/src/main/java/com/clokey/server/domain/MemberLike/dao/MemberLikeRepository.java
@@ -8,4 +8,8 @@ public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
     int countByHistory_Id(Long historyId);
 
     boolean existsByMember_IdAndHistory_Id(Long memberId, Long historyId);
+
+    void deleteByMemberIdAndHistoryId(Long memberId, Long historyId);
+
+
 }

--- a/src/main/java/com/clokey/server/domain/MemberLike/dao/MemberLikeRepository.java
+++ b/src/main/java/com/clokey/server/domain/MemberLike/dao/MemberLikeRepository.java
@@ -9,7 +9,6 @@ public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
 
     boolean existsByMember_IdAndHistory_Id(Long memberId, Long historyId);
 
-    void deleteByMemberIdAndHistoryId(Long memberId, Long historyId);
-
+    void deleteByMember_IdAndHistory_Id(Long memberId, Long historyId);
 
 }

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -44,7 +44,6 @@ public class HistoryRestController {
     private final HistoryAccessibleValidator historyAccessibleValidator;
 
     //임시로 엔드 포인트 맨 뒤에 멤버 Id를 받도록 했습니다 토큰에서 나의 id를 가져올 수 있도록 수정해야함.
-    //이유는 isLiked를 확인해야 하기 때문입니다. ㅠ ㅠ
     @GetMapping("/daily/{historyId}/{memberId}")
     @Operation(summary = "특정 일의 기록을 확인할 수 있는 API",description = "path variable로 history_id를 넘겨주세요.")
     @ApiResponses({
@@ -64,7 +63,7 @@ public class HistoryRestController {
         int likeCount = memberLikeRepositoryService.countLikesOfHistory(historyId);
         boolean isLiked = memberLikeRepositoryService.memberLikedHistory(memberId, historyId);
 
-        return BaseResponse.onSucesss(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toDayViewResult(history.get(),imageUrl,hashtags,likeCount,isLiked));
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toDayViewResult(history.get(),imageUrl,hashtags,likeCount,isLiked));
     }
 
     //임시로 멤버 Id를 받도록 했습니다 토큰에서 나의 id를 가져올 수 있도록 수정해야함.
@@ -90,12 +89,14 @@ public class HistoryRestController {
 
         //나의 기록 열람은 공개 범위와 상관없이 모두 열람 가능합니다.
         if(this_member_id.equals(memberId)) {
-            return BaseResponse.onSucesss(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toAllMonthViewResult(memberId,histories,historyImageUrls));
+            return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toAllMonthViewResult(memberId,histories,historyImageUrls));
         }
 
         //다른 멤버 기록 열람시 PUBLIC 기록만을 모아줍니다.
-        return BaseResponse.onSucesss(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toPublicMonthViewResult(memberId,histories,historyImageUrls));
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toPublicMonthViewResult(memberId,histories,historyImageUrls));
     }
+
+
 
 
 

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -3,6 +3,7 @@ package com.clokey.server.domain.history.api;
 import com.clokey.server.domain.HashtagHistory.application.HashtagHistoryRepositoryService;
 import com.clokey.server.domain.HistoryImage.application.HistoryImageRepositoryService;
 import com.clokey.server.domain.MemberLike.application.MemberLikeRepositoryService;
+import com.clokey.server.domain.history.application.HistoryService;
 import com.clokey.server.domain.history.converter.HistoryConverter;
 import com.clokey.server.domain.history.application.HistoryRepositoryService;
 import com.clokey.server.domain.history.dto.HistoryRequestDto;
@@ -40,6 +41,7 @@ public class HistoryRestController {
     private final MemberLikeRepositoryService memberLikeRepositoryService;
     private final HistoryLikedValidator historyLikedValidator;
     private final HistoryAccessibleValidator historyAccessibleValidator;
+    private final HistoryService historyService;
 
     //임시로 엔드 포인트 맨 뒤에 멤버 Id를 받도록 했습니다 토큰에서 나의 id를 가져올 수 있도록 수정해야함.
     @GetMapping("/daily/{historyId}/{memberId}")
@@ -110,7 +112,7 @@ public class HistoryRestController {
         historyLikedValidator.validateIsLiked(thisMemberId, request.getHistoryId(), request.isLiked());
 
         //isLiked의 상태에 따라서 좋아요 -> 취소 , 좋아요가 없는 상태 -> 좋아요 로 바꿔주게 됩니다.
-        memberLikeRepositoryService.changeLike(thisMemberId, request.getHistoryId(), request.isLiked());
+        historyService.changeLike(thisMemberId, request.getHistoryId(), request.isLiked());
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_LIKE_STATUS_CHANGED, HistoryConverter.toLikeResult(
                 historyRepositoryService.getHistoryById(request.getHistoryId()).get(),

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -10,6 +10,7 @@ import com.clokey.server.domain.history.dto.HistoryResponseDto;
 import com.clokey.server.domain.history.exception.annotation.HistoryExist;
 import com.clokey.server.domain.history.exception.annotation.MonthFormat;
 import com.clokey.server.domain.history.exception.validator.HistoryAccessibleValidator;
+import com.clokey.server.domain.history.exception.validator.HistoryLikedValidator;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.exception.annotation.MemberExist;
 import com.clokey.server.domain.model.History;
@@ -37,7 +38,7 @@ public class HistoryRestController {
     private final HistoryRepositoryService historyRepositoryService;
     private final HashtagHistoryRepositoryService hashtagHistoryRepositoryService;
     private final MemberLikeRepositoryService memberLikeRepositoryService;
-    private final MemberRepositoryService memberRepositoryService;
+    private final HistoryLikedValidator historyLikedValidator;
     private final HistoryAccessibleValidator historyAccessibleValidator;
 
     //임시로 엔드 포인트 맨 뒤에 멤버 Id를 받도록 했습니다 토큰에서 나의 id를 가져올 수 있도록 수정해야함.
@@ -105,6 +106,10 @@ public class HistoryRestController {
     public BaseResponse<HistoryResponseDto.likeResult> like(@PathVariable Long thisMemberId,
                                                             @RequestBody @Valid HistoryRequestDto.likeStatusChange request) {
 
+        //isLiked 정보가 정확한지 검증합니다.
+        historyLikedValidator.validateIsLiked(thisMemberId, request.getHistoryId(), request.isLiked());
+
+        //isLiked의 상태에 따라서 좋아요 -> 취소 , 좋아요가 없는 상태 -> 좋아요 로 바꿔주게 됩니다.
         memberLikeRepositoryService.changeLike(thisMemberId, request.getHistoryId(), request.isLiked());
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_LIKE_STATUS_CHANGED, HistoryConverter.toLikeResult(

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -5,6 +5,7 @@ import com.clokey.server.domain.HistoryImage.application.HistoryImageRepositoryS
 import com.clokey.server.domain.MemberLike.application.MemberLikeRepositoryService;
 import com.clokey.server.domain.history.converter.HistoryConverter;
 import com.clokey.server.domain.history.application.HistoryRepositoryService;
+import com.clokey.server.domain.history.dto.HistoryRequestDto;
 import com.clokey.server.domain.history.dto.HistoryResponseDto;
 import com.clokey.server.domain.history.exception.annotation.HistoryExist;
 import com.clokey.server.domain.history.exception.annotation.MonthFormat;
@@ -13,14 +14,10 @@ import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.exception.annotation.MemberExist;
 import com.clokey.server.domain.model.History;
 import com.clokey.server.global.common.response.BaseResponse;
-import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,9 +42,9 @@ public class HistoryRestController {
 
     //임시로 엔드 포인트 맨 뒤에 멤버 Id를 받도록 했습니다 토큰에서 나의 id를 가져올 수 있도록 수정해야함.
     @GetMapping("/daily/{historyId}/{memberId}")
-    @Operation(summary = "특정 일의 기록을 확인할 수 있는 API",description = "path variable로 history_id를 넘겨주세요.")
+    @Operation(summary = "특정 일의 기록을 확인할 수 있는 API", description = "path variable로 history_id를 넘겨주세요.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_200",description = "OK, 성공적으로 조회되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_200", description = "OK, 성공적으로 조회되었습니다."),
     })
     @Parameters({
             @Parameter(name = "historyId", description = "기록의 id, path variable 입니다.")
@@ -55,7 +52,7 @@ public class HistoryRestController {
     public BaseResponse<HistoryResponseDto.dayViewResult> getDaily(@PathVariable @Valid @HistoryExist Long historyId, @PathVariable Long memberId) {
 
         //멤버가 기록에 대해서 접근 권한이 있는지 확인합니다.
-        historyAccessibleValidator.validateHistoryAccessOfMember(historyId,memberId);
+        historyAccessibleValidator.validateHistoryAccessOfMember(historyId, memberId);
 
         Optional<History> history = historyRepositoryService.getHistoryById(historyId);
         List<String> imageUrl = historyImageRepositoryService.getHistoryImageUrls(historyId);
@@ -63,41 +60,58 @@ public class HistoryRestController {
         int likeCount = memberLikeRepositoryService.countLikesOfHistory(historyId);
         boolean isLiked = memberLikeRepositoryService.memberLikedHistory(memberId, historyId);
 
-        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toDayViewResult(history.get(),imageUrl,hashtags,likeCount,isLiked));
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS, HistoryConverter.toDayViewResult(history.get(), imageUrl, hashtags, likeCount, isLiked));
     }
 
     //임시로 멤버 Id를 받도록 했습니다 토큰에서 나의 id를 가져올 수 있도록 수정해야함.
     //결국 자신의 기록을 보는지 확인하기 위해 MemberId 쿼리 파라미터는 필수적으로 받아야합니다.
     @GetMapping("/monthly/{this_member_id}/")
-    @Operation(summary = "특정 멤버의 특정 월의 기록을 확인할 수 있는 API",description = "query parameter로 member_id와 month를 입력해주세요(YYYY-MM) 형태.")
+    @Operation(summary = "특정 멤버의 특정 월의 기록을 확인할 수 있는 API", description = "query parameter로 member_id와 month를 입력해주세요(YYYY-MM) 형태.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_200",description = "성공적으로 조회되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_200", description = "성공적으로 조회되었습니다."),
     })
     @Parameters({
             @Parameter(name = "memberId", description = "조회하고자 하는 memberId, 빈칸 입력시 현재 유저를 기준으로 합니다."),
             @Parameter(name = "month", description = "조회하고자 하는 월입니다. YYYY-MM 형식으로 입력해주세요.")
     })
     public BaseResponse<HistoryResponseDto.monthViewResult> getMonthlyHistories(@PathVariable Long this_member_id,
-            @RequestParam(value = "memberId") @Valid @MemberExist Long memberId,
-            @RequestParam(value = "month") @Valid @MonthFormat String month) {
+                                                                                @RequestParam(value = "memberId") @Valid @MemberExist Long memberId,
+                                                                                @RequestParam(value = "month") @Valid @MonthFormat String month) {
 
         //멤버 자체에 대한 접근 권한 확인.
-        historyAccessibleValidator.validateMemberAccessOfMember(memberId,this_member_id);
+        historyAccessibleValidator.validateMemberAccessOfMember(memberId, this_member_id);
 
         List<History> histories = historyRepositoryService.getMemberHistoryByYearMonth(memberId, month);
         List<String> historyImageUrls = historyRepositoryService.getFirstImageUrlsOfHistory(histories);
 
         //나의 기록 열람은 공개 범위와 상관없이 모두 열람 가능합니다.
-        if(this_member_id.equals(memberId)) {
-            return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toAllMonthViewResult(memberId,histories,historyImageUrls));
+        if (this_member_id.equals(memberId)) {
+            return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS, HistoryConverter.toAllMonthViewResult(memberId, histories, historyImageUrls));
         }
 
         //다른 멤버 기록 열람시 PUBLIC 기록만을 모아줍니다.
-        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toPublicMonthViewResult(memberId,histories,historyImageUrls));
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS, HistoryConverter.toPublicMonthViewResult(memberId, histories, historyImageUrls));
     }
 
+    //사용자 토큰 받는 부분 추가해야함.
+    @PostMapping("/like/{thisMemberId}")
+    @Operation(summary = "특정 기록에 좋아요를 누를 수 있는 API", description = "history의 ID와 isLiked 정보를 body에 넣어서 넘겨주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_200", description = "좋아요 상태가 성공적으로 변경되었습니다."),
+    })
+    @Parameters({
+            @Parameter(name = "thisMemberId", description = "현재 유저의 ID 토큰 대체용입니다.")
+    })
+    public BaseResponse<HistoryResponseDto.likeResult> like(@PathVariable Long thisMemberId,
+                                                            @RequestBody @Valid HistoryRequestDto.likeStatusChange request) {
 
+        memberLikeRepositoryService.changeLike(thisMemberId, request.getHistoryId(), request.isLiked());
 
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_LIKE_STATUS_CHANGED, HistoryConverter.toLikeResult(
+                historyRepositoryService.getHistoryById(request.getHistoryId()).get(),
+                request.isLiked()
+        ));
+    }
 
 
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
@@ -1,0 +1,6 @@
+package com.clokey.server.domain.history.application;
+
+public interface HistoryService {
+
+    void changeLike(Long memberId, Long historyId, boolean isLiked);
+}

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -1,0 +1,25 @@
+package com.clokey.server.domain.history.application;
+
+import com.clokey.server.domain.MemberLike.application.MemberLikeRepositoryService;
+import com.clokey.server.domain.history.dao.HistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryServiceImpl implements HistoryService{
+
+    private final MemberLikeRepositoryService memberLikeRepositoryService;
+    private final HistoryRepository historyRepository;
+
+    @Override
+    public void changeLike(Long memberId, Long historyId, boolean isLiked) {
+        if(isLiked) {
+            historyRepository.decrementLikes(historyId);
+            memberLikeRepositoryService.deleteLike(memberId,historyId);
+        } else {
+            historyRepository.incrementLikes(historyId);
+            memberLikeRepositoryService.saveLike(memberId,historyId);
+        }
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -75,7 +75,7 @@ public class HistoryConverter {
     public static HistoryResponseDto.likeResult toLikeResult(History history, boolean isLiked){
         return HistoryResponseDto.likeResult.builder()
                 .historyId(history.getId())
-                .isLiked(isLiked)
+                .isLiked(!isLiked)
                 .likeCount(history.getLikes())
                 .build();
     }

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -71,5 +71,13 @@ public class HistoryConverter {
                 .imageUrl(historyImageUrl)
                 .build();
     }
+
+    public static HistoryResponseDto.likeResult toLikeResult(History history, boolean isLiked){
+        return HistoryResponseDto.likeResult.builder()
+                .historyId(history.getId())
+                .isLiked(isLiked)
+                .likeCount(history.getLikes())
+                .build();
+    }
 }
 

--- a/src/main/java/com/clokey/server/domain/history/dao/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/dao/HistoryRepository.java
@@ -1,7 +1,9 @@
 package com.clokey.server.domain.history.dao;
 
 import com.clokey.server.domain.model.History;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +14,14 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("SELECT h FROM History h WHERE h.member.id = :memberId AND FUNCTION('DATE_FORMAT', h.historyDate, '%Y-%m') = :yearMonth")
     List<History> findHistoriesByMemberAndYearMonth(@Param("memberId") Long memberId, @Param("yearMonth") String yearMonth);
 
+    @Transactional
+    @Modifying
+    @Query("UPDATE History h SET h.likes = h.likes + 1 WHERE h.id = :historyId")
+    void incrementLikes(Long historyId);
+
+    // Likes 감소
+    @Transactional
+    @Modifying
+    @Query("UPDATE History h SET h.likes = h.likes - 1 WHERE h.id = :historyId")
+    void decrementLikes(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDto.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDto.java
@@ -1,0 +1,21 @@
+package com.clokey.server.domain.history.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class HistoryRequestDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class likeOrCancelLikeHistory{
+        Long historyId;
+        boolean isLiked;
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDto.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDto.java
@@ -1,6 +1,8 @@
 package com.clokey.server.domain.history.dto;
 
 import com.clokey.server.domain.history.exception.annotation.HistoryExist;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +20,7 @@ public class HistoryRequestDto {
         @HistoryExist
         Long historyId;
 
-        @NotNull
+        @JsonProperty("liked")
         boolean isLiked;
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDto.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDto.java
@@ -1,12 +1,11 @@
 package com.clokey.server.domain.history.dto;
 
+import com.clokey.server.domain.history.exception.annotation.HistoryExist;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
-import java.util.List;
 
 public class HistoryRequestDto {
 
@@ -14,8 +13,12 @@ public class HistoryRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class likeOrCancelLikeHistory{
+    public static class likeStatusChange {
+
+        @HistoryExist
         Long historyId;
+
+        @NotNull
         boolean isLiked;
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDto.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDto.java
@@ -43,7 +43,16 @@ public class HistoryResponseDto {
         LocalDate date;
         String imageUrl;
     }
-}
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class likeResult{
+        Long historyId;
+        boolean isLiked;
+        int likeCount;
+    }
+}
 
 

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryExist.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryExist.java
@@ -12,7 +12,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HistoryExist {
 
-    String message() default "해당하는 카테고리가 존재하지 않습니다.";
+    String message() default "해당하는 기록이 존재하지 않습니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryLikedValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryLikedValidator.java
@@ -1,0 +1,28 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.MemberLike.application.MemberLikeRepositoryService;
+import com.clokey.server.domain.model.History;
+import com.clokey.server.domain.model.enums.Visibility;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import com.clokey.server.global.error.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class HistoryLikedValidator {
+
+    private final MemberLikeRepositoryService memberLikeRepositoryService;
+
+    public void validateIsLiked(Long historyId, Long memberId, boolean isLiked) {
+
+        boolean isValid = memberLikeRepositoryService.memberLikedHistory(memberId,historyId) == isLiked;
+
+        if (!isValid) {
+            throw new GeneralException(ErrorStatus.IS_LIKED_INVALID);
+        }
+    }
+
+}

--- a/src/main/java/com/clokey/server/domain/model/History.java
+++ b/src/main/java/com/clokey/server/domain/model/History.java
@@ -4,6 +4,7 @@ import com.clokey.server.domain.model.enums.MemberStatus;
 import com.clokey.server.domain.model.enums.Visibility;
 import com.clokey.server.domain.model.mapping.MemberLike;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -24,6 +25,7 @@ public class History extends BaseEntity {
     @Column(nullable = false)
     private LocalDate historyDate;
 
+    @Min(0)
     @Column(nullable = false, columnDefinition = "integer default 0")
     private int likes;
 

--- a/src/main/java/com/clokey/server/domain/model/mapping/MemberLike.java
+++ b/src/main/java/com/clokey/server/domain/model/mapping/MemberLike.java
@@ -10,6 +10,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "history_id"}))
 public class MemberLike extends BaseEntity {
 
     @Id

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -46,7 +46,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //기록 에러
     DATE_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4001","잘못된 날짜 형식입니다."),
-
     NO_SUCH_HISTORY(HttpStatus.NOT_FOUND,"HISTORY_4002","존재하지 않는 기록 ID입니다."),
     HISTORY_VISIBILITY_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4003","잘못된 visibility 값을 입력했습니다."),
     ISLIKED_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4004","잘못된 isLiked 값을 입력했습니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -48,7 +48,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DATE_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4001","잘못된 날짜 형식입니다."),
     NO_SUCH_HISTORY(HttpStatus.NOT_FOUND,"HISTORY_4002","존재하지 않는 기록 ID입니다."),
     HISTORY_VISIBILITY_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4003","잘못된 visibility 값을 입력했습니다."),
-    ISLIKED_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4004","잘못된 isLiked 값을 입력했습니다."),
+    IS_LIKED_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4004","잘못된 isLiked 값을 입력했습니다."),
     NO_SUCH_COMMENT(HttpStatus.NOT_FOUND,"HISTORY_4005","존재하지 않는 댓글 ID입니다."),
     NO_PERMISSION_TO_ACCESS_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4006","기록에 접근 권한이 없습니다."),
 

--- a/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
@@ -35,6 +35,7 @@ public enum SuccessStatus implements BaseCode {
     //기록 성공
     HISTORY_SUCCESS(HttpStatus.OK, "HISTORY_200", "성공적으로 조회되었습니다."),
     HISTORY_CREATED(HttpStatus.CREATED, "HISTORY_201", "성공적으로 생성되었습니다."),
+    HISTORY_LIKE_STATUS_CHANGED(HttpStatus.OK,"HISTORY_200","좋아요 상태가 성공적으로 변경되었습니다."),
 
     //알림 성공
     NOTIFICATION_SUCCESS(HttpStatus.OK, "NOTIFICATION_200", "성공적으로 조회되었습니다."),

--- a/src/main/java/com/clokey/server/global/error/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/clokey/server/global/error/exception/GlobalExceptionAdvice.java
@@ -5,9 +5,11 @@ import com.clokey.server.global.error.code.ErrorReasonDTO;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpHeaders;
@@ -77,8 +79,12 @@ public class GlobalExceptionAdvice extends ResponseEntityExceptionHandler {
                 .forEach(
                         fieldError -> {
                             String fieldName = fieldError.getField();
-                            String errorMessage =
-                                    Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                            String errorMessage;
+                            try {
+                                errorMessage = Optional.ofNullable(ErrorStatus.valueOf(fieldError.getDefaultMessage()).getMessage()).orElse("");
+                            } catch (IllegalArgumentException ex) {
+                                errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                            }
                             errors.merge(
                                     fieldName,
                                     errorMessage,


### PR DESCRIPTION
## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #30 

## 🌱 PR 요약
- 기록에 좋아요를 누를 수 있는 기능 구현
- 좋아요를 취소할수도 있습니다

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
좋아요 누르기 / 취소 기능 api입니다. 
특정 history를 조회한 후 호출되는 경우를 생각했습니다.

- 이전의 isLiked 상태를 던져주면 반대 상태로 바꿔줍니다.
- 현재 유저의 토큰을 받아와야 합니다. 우선 path parameter로 대체.

📌 오류
- 존재하는 history 인지 검증합니다.
- isLiked 정보가 맞는지 검증합니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

- 성공한 경우 
<img width="524" alt="스크린샷 2025-01-13 오후 6 39 52" src="https://github.com/user-attachments/assets/d3dfb680-eb32-4297-b1e5-7ae66fbc5fbc" />


- 존재하지 않는 기록을 입력한 경우
<img width="761" alt="스크린샷 2025-01-13 오후 6 39 23" src="https://github.com/user-attachments/assets/ffe48d3f-c421-4018-87cb-79decb6820c3" />

- isLiked 정보가 틀린 경우.
<img width="678" alt="스크린샷 2025-01-13 오후 6 38 23" src="https://github.com/user-attachments/assets/3198cf57-d2ac-4238-bfc3-dcc7e04f1fcd" />


## ❗️리뷰어들께
