### PR TITLE
[Feat/#32] 댓글 조회 기능 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryService.java
@@ -9,7 +9,7 @@ public interface CommentRepositoryService {
 
     boolean commentExist(Long commentId);
 
-    List<Comment> getRepliesByCommentId(Long commentId);
+    List<List<Comment>> getReplyListOfCommentList(Page<Comment> comments);
 
     Page<Comment> getNoneReplyCommentsByHistoryId(Long historyId, Integer page);
 }

--- a/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryService.java
@@ -1,6 +1,7 @@
 package com.clokey.server.domain.comment.application;
 
 import com.clokey.server.domain.model.Comment;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -10,5 +11,5 @@ public interface CommentRepositoryService {
 
     List<Comment> getRepliesByCommentId(Long commentId);
 
-    List<Comment> getNoneReplyCommentsByHistoryId(Long historyId);
+    Page<Comment> getNoneReplyCommentsByHistoryId(Long historyId, Integer page);
 }

--- a/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryService.java
@@ -1,7 +1,14 @@
 package com.clokey.server.domain.comment.application;
 
+import com.clokey.server.domain.model.Comment;
+
+import java.util.List;
+
 public interface CommentRepositoryService {
 
     boolean commentExist(Long commentId);
 
+    List<Comment> getRepliesByCommentId(Long commentId);
+
+    List<Comment> getNoneReplyCommentsByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryServiceImpl.java
@@ -22,8 +22,10 @@ public class CommentRepositoryServiceImpl implements CommentRepositoryService{
     }
 
     @Override
-    public List<Comment> getRepliesByCommentId(Long commentId) {
-        return commentRepository.findByCommentId(commentId);
+    public List<List<Comment>> getReplyListOfCommentList(Page<Comment> comments) {
+        return comments.stream()
+                .map(comment -> commentRepository.findByCommentId(comment.getId()))
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryServiceImpl.java
@@ -3,6 +3,9 @@ package com.clokey.server.domain.comment.application;
 import com.clokey.server.domain.comment.dao.CommentRepository;
 import com.clokey.server.domain.model.Comment;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,7 +27,7 @@ public class CommentRepositoryServiceImpl implements CommentRepositoryService{
     }
 
     @Override
-    public List<Comment> getNoneReplyCommentsByHistoryId(Long historyId) {
-        return commentRepository.findByHistoryIdAndCommentIsNull(historyId);
+    public Page<Comment> getNoneReplyCommentsByHistoryId(Long historyId, Integer page) {
+        return commentRepository.findByHistoryIdAndCommentIsNull(historyId, PageRequest.of(page,10,Sort.by(Sort.Direction.ASC, "createdAt")));
     }
 }

--- a/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/comment/application/CommentRepositoryServiceImpl.java
@@ -1,8 +1,11 @@
 package com.clokey.server.domain.comment.application;
 
 import com.clokey.server.domain.comment.dao.CommentRepository;
+import com.clokey.server.domain.model.Comment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,5 +16,15 @@ public class CommentRepositoryServiceImpl implements CommentRepositoryService{
     @Override
     public boolean commentExist(Long commentId) {
         return commentRepository.existsById(commentId);
+    }
+
+    @Override
+    public List<Comment> getRepliesByCommentId(Long commentId) {
+        return commentRepository.findByCommentId(commentId);
+    }
+
+    @Override
+    public List<Comment> getNoneReplyCommentsByHistoryId(Long historyId) {
+        return commentRepository.findByHistoryIdAndCommentIsNull(historyId);
     }
 }

--- a/src/main/java/com/clokey/server/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/clokey/server/domain/comment/dao/CommentRepository.java
@@ -3,5 +3,11 @@ package com.clokey.server.domain.comment.dao;
 import com.clokey.server.domain.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByHistoryIdAndCommentIsNull(Long historyId);
+
+    List<Comment> findByCommentId(Long parentId);
 }

--- a/src/main/java/com/clokey/server/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/clokey/server/domain/comment/dao/CommentRepository.java
@@ -1,13 +1,15 @@
 package com.clokey.server.domain.comment.dao;
 
 import com.clokey.server.domain.model.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    List<Comment> findByHistoryIdAndCommentIsNull(Long historyId);
+    Page<Comment> findByHistoryIdAndCommentIsNull(Long historyId, PageRequest pageRequest);
 
     List<Comment> findByCommentId(Long parentId);
 }

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -13,14 +13,10 @@ import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.exception.annotation.MemberExist;
 import com.clokey.server.domain.model.History;
 import com.clokey.server.global.common.response.BaseResponse;
-import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -53,7 +49,7 @@ public class HistoryRestController {
     @Parameters({
             @Parameter(name = "historyId", description = "기록의 id, path variable 입니다.")
     })
-    public BaseResponse<HistoryResponseDto.dayViewResult> getDaily(@PathVariable @Valid @HistoryExist Long historyId, @PathVariable Long memberId) {
+    public BaseResponse<HistoryResponseDto.DayViewResult> getDaily(@PathVariable @Valid @HistoryExist Long historyId, @PathVariable Long memberId) {
 
         //멤버가 기록에 대해서 접근 권한이 있는지 확인합니다.
         historyAccessibleValidator.validateHistoryAccessOfMember(historyId,memberId);
@@ -64,7 +60,7 @@ public class HistoryRestController {
         int likeCount = memberLikeRepositoryService.countLikesOfHistory(historyId);
         boolean isLiked = memberLikeRepositoryService.memberLikedHistory(memberId, historyId);
 
-        return BaseResponse.onSucesss(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toDayViewResult(history.get(),imageUrl,hashtags,likeCount,isLiked));
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toDayViewResult(history.get(),imageUrl,hashtags,likeCount,isLiked));
     }
 
     //임시로 멤버 Id를 받도록 했습니다 토큰에서 나의 id를 가져올 수 있도록 수정해야함.
@@ -78,9 +74,9 @@ public class HistoryRestController {
             @Parameter(name = "memberId", description = "조회하고자 하는 memberId, 빈칸 입력시 현재 유저를 기준으로 합니다."),
             @Parameter(name = "month", description = "조회하고자 하는 월입니다. YYYY-MM 형식으로 입력해주세요.")
     })
-    public BaseResponse<HistoryResponseDto.monthViewResult> getMonthlyHistories(@PathVariable Long this_member_id,
-            @RequestParam(value = "memberId") @Valid @MemberExist Long memberId,
-            @RequestParam(value = "month") @Valid @MonthFormat String month) {
+    public BaseResponse<HistoryResponseDto.MonthViewResult> getMonthlyHistories(@PathVariable Long this_member_id,
+                                                                                @RequestParam(value = "memberId") @Valid @MemberExist Long memberId,
+                                                                                @RequestParam(value = "month") @Valid @MonthFormat String month) {
 
         //멤버 자체에 대한 접근 권한 확인.
         historyAccessibleValidator.validateMemberAccessOfMember(memberId,this_member_id);
@@ -90,11 +86,11 @@ public class HistoryRestController {
 
         //나의 기록 열람은 공개 범위와 상관없이 모두 열람 가능합니다.
         if(this_member_id.equals(memberId)) {
-            return BaseResponse.onSucesss(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toAllMonthViewResult(memberId,histories,historyImageUrls));
+            return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toAllMonthViewResult(memberId,histories,historyImageUrls));
         }
 
         //다른 멤버 기록 열람시 PUBLIC 기록만을 모아줍니다.
-        return BaseResponse.onSucesss(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toPublicMonthViewResult(memberId,histories,historyImageUrls));
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS,HistoryConverter.toPublicMonthViewResult(memberId,histories,historyImageUrls));
     }
 
 

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -1,5 +1,6 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.model.Comment;
 import com.clokey.server.domain.model.History;
 
 import java.util.List;

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -94,7 +94,7 @@ public class HistoryConverter {
                     List<Comment> replyList = replies.get(i);
                     return HistoryResponseDto.CommentResult.builder()
                             .commentId(comment.getId())
-                            .MemberId(comment.getMember().getId())
+                            .memberId(comment.getMember().getId())
                             .userImageUrl(comment.getMember().getProfileImageUrl())
                             .content(comment.getContent())
                             .replyResults(toReplyResultList(replyList))

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 public class HistoryConverter {
 
-    public static HistoryResponseDto.dayViewResult toDayViewResult(History history, List<String> imageUrl, List<String> hashtags, int likeCount, boolean isLiked) {
-        return HistoryResponseDto.dayViewResult.builder()
+    public static HistoryResponseDto.DayViewResult toDayViewResult(History history, List<String> imageUrl, List<String> hashtags, int likeCount, boolean isLiked) {
+        return HistoryResponseDto.DayViewResult.builder()
                 .userId(history.getMember().getId())
                 .contents(history.getContent())
                 .imageUrl(imageUrl)
@@ -22,9 +22,9 @@ public class HistoryConverter {
                 .build();
     }
 
-    public static HistoryResponseDto.monthViewResult toPublicMonthViewResult(Long memberId, List<History> histories , List<String> historyFirstImageUrls) {
+    public static HistoryResponseDto.MonthViewResult toPublicMonthViewResult(Long memberId, List<History> histories , List<String> historyFirstImageUrls) {
 
-        List<HistoryResponseDto.historyResult> historyResults = new ArrayList<>();
+        List<HistoryResponseDto.HistoryResult> HistoryResults = new ArrayList<>();
 
         for (int i = 0; i < histories.size(); i++) {
             History history = histories.get(i);
@@ -38,34 +38,34 @@ public class HistoryConverter {
                 historyImageUrl = "비공개입니다";
             }
 
-            historyResults.add(toHistoryResult(history, historyImageUrl));
+            HistoryResults.add(toHistoryResult(history, historyImageUrl));
         }
 
-        return HistoryResponseDto.monthViewResult.builder()
+        return HistoryResponseDto.MonthViewResult.builder()
                 .userId(memberId)
-                .histories(historyResults)
+                .histories(HistoryResults)
                 .build();
     }
 
-    public static HistoryResponseDto.monthViewResult toAllMonthViewResult(Long memberId, List<History> histories , List<String> historyFirstImageUrls) {
+    public static HistoryResponseDto.MonthViewResult toAllMonthViewResult(Long memberId, List<History> histories , List<String> historyFirstImageUrls) {
 
-        List<HistoryResponseDto.historyResult> historyResults = new ArrayList<>();
+        List<HistoryResponseDto.HistoryResult> HistoryResults = new ArrayList<>();
 
         for (int i = 0; i < histories.size(); i++) {
             History history = histories.get(i);
             String historyImageUrl = historyFirstImageUrls.get(i);
 
-            historyResults.add(toHistoryResult(history, historyImageUrl));
+            HistoryResults.add(toHistoryResult(history, historyImageUrl));
         }
 
-        return HistoryResponseDto.monthViewResult.builder()
+        return HistoryResponseDto.MonthViewResult.builder()
                 .userId(memberId)
-                .histories(historyResults)
+                .histories(HistoryResults)
                 .build();
     }
 
-    private static HistoryResponseDto.historyResult toHistoryResult(History history, String historyImageUrl) {
-        return HistoryResponseDto.historyResult.builder()
+    private static HistoryResponseDto.HistoryResult toHistoryResult(History history, String historyImageUrl) {
+        return HistoryResponseDto.HistoryResult.builder()
                 .historyId(history.getId())
                 .date(history.getHistoryDate())
                 .imageUrl(historyImageUrl)

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -1,11 +1,14 @@
 package com.clokey.server.domain.history.converter;
 
 import com.clokey.server.domain.history.dto.HistoryResponseDto;
+import com.clokey.server.domain.model.Comment;
 import com.clokey.server.domain.model.History;
 import com.clokey.server.domain.model.enums.Visibility;
+import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 public class HistoryConverter {
 
@@ -71,5 +74,46 @@ public class HistoryConverter {
                 .imageUrl(historyImageUrl)
                 .build();
     }
+
+    public static HistoryResponseDto.HistoryCommentResult toHistoryCommentResult(Page<Comment> comments, List<List<Comment>> replies) {
+        return HistoryResponseDto.HistoryCommentResult.builder()
+                .comments(toCommentResultList(comments,replies))
+                .totalPage(comments.getTotalPages())
+                .totalElements(comments.getNumberOfElements())
+                .isFirst(comments.isFirst())
+                .isLast(comments.isLast())
+                .build();
+    };
+
+
+
+    private static List<HistoryResponseDto.CommentResult> toCommentResultList(Page<Comment> comments, List<List<Comment>> replies) {
+        return IntStream.range(0, comments.getContent().size())
+                .mapToObj(i -> {
+                    Comment comment = comments.getContent().get(i);
+                    List<Comment> replyList = replies.get(i);
+                    return HistoryResponseDto.CommentResult.builder()
+                            .commentId(comment.getId())
+                            .MemberId(comment.getMember().getId())
+                            .userImageUrl(comment.getMember().getProfileImageUrl())
+                            .content(comment.getContent())
+                            .replyResults(toReplyResultList(replyList))
+                            .build();
+                })
+                .toList();
+    }
+
+    private static List<HistoryResponseDto.ReplyResult> toReplyResultList(List<Comment> replies) {
+        return replies.stream()
+                .map(reply->HistoryResponseDto.ReplyResult.builder()
+                        .commentId(reply.getId())
+                        .MemberId(reply.getMember().getId())
+                        .userImageUrl(reply.getMember().getProfileImageUrl())
+                        .content(reply.getContent())
+                        .build())
+                .toList();
+    }
+
+
 }
 

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDto.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDto.java
@@ -1,5 +1,6 @@
 package com.clokey.server.domain.history.dto;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -61,9 +62,10 @@ public class HistoryResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonPropertyOrder({"commentId", "memberId", "userImageUrl", "content", "replyResults"})
     public static class CommentResult{
         Long commentId;
-        Long MemberId;
+        Long memberId;
         String userImageUrl;
         String content;
         List<ReplyResult> replyResults;

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDto.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDto.java
@@ -14,7 +14,7 @@ public class HistoryResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class dayViewResult{
+    public static class DayViewResult {
         Long userId;
         String contents;
         List<String> imageUrl;
@@ -29,20 +29,57 @@ public class HistoryResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class monthViewResult{
+    public static class MonthViewResult {
         Long userId;
-        List<historyResult> histories;
+        List<HistoryResult> histories;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class historyResult{
+    public static class HistoryResult {
         Long historyId;
         LocalDate date;
         String imageUrl;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HistoryCommentResult {
+        List<CommentResult> comments;
+        int totalPage;
+        int totalElements;
+        boolean isFirst;
+        boolean isLast;
+    }
+
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentResult{
+        Long commentId;
+        Long MemberId;
+        String userImageUrl;
+        String content;
+        List<ReplyResult> replyResults;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReplyResult{
+        Long commentId;
+        Long MemberId;
+        String userImageUrl;
+        String content;
+    }
+
 }
 
 

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/CheckPage.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/CheckPage.java
@@ -1,0 +1,18 @@
+package com.clokey.server.domain.history.exception.annotation;
+
+import com.clokey.server.domain.history.exception.validator.CheckPageValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckPageValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPage {
+
+    String message() default "페이지가 1보다 작을 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/CheckPageValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/CheckPageValidator.java
@@ -1,0 +1,31 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.history.exception.annotation.CheckPage;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckPageValidator implements ConstraintValidator<CheckPage, Integer> {
+
+    @Override
+    public void initialize(CheckPage constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        boolean isValid = value > 0;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.PAGE_UNDER_ONE.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -16,7 +16,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     //페이징 에러
-    PAGE_INVALID(HttpStatus.NOT_FOUND,"PAGE_4041","존재하지 않는 페이지입니다."),
+    PAGE_UNDER_ONE(HttpStatus.NOT_FOUND,"PAGE_4001","페이지는 1이상이여야 합니다."),
 
     //멤버 에러
     NO_SUCH_TERM(HttpStatus.NOT_FOUND,"MEMBER_4041","존재하지 않는 약관ID입니다."),
@@ -46,10 +46,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //기록 에러
     DATE_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4001","잘못된 날짜 형식입니다."),
-
     NO_SUCH_HISTORY(HttpStatus.NOT_FOUND,"HISTORY_4002","존재하지 않는 기록 ID입니다."),
     HISTORY_VISIBILITY_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4003","잘못된 visibility 값을 입력했습니다."),
-    ISLIKED_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4004","잘못된 isLiked 값을 입력했습니다."),
+    IS_LIKED_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4004","잘못된 isLiked 값을 입력했습니다."),
     NO_SUCH_COMMENT(HttpStatus.NOT_FOUND,"HISTORY_4005","존재하지 않는 댓글 ID입니다."),
     NO_PERMISSION_TO_ACCESS_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4006","기록에 접근 권한이 없습니다."),
 
@@ -63,8 +62,6 @@ public enum ErrorStatus implements BaseErrorCode {
     //추천 에러
     NO_TEMP_PARAMETER(HttpStatus.BAD_REQUEST,"RECOMMEND_4001","온도값은 필수입니다."),
 
-    // 공통 에러
-    PAGE_UNDER_ZERO(HttpStatus.BAD_REQUEST, "COMM4001", "페이지는 0이상이어야 합니다."),
     ;
 
 


### PR DESCRIPTION
## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #32

## 🌱 PR 요약

- 댓글 조회 기능을 구현했습니다.
- 페이징이 구현되어 있습니다.

## 🛠 작업 내용
- 페이징에 맞게 댓글 조회기능 구현.

## 📸 스크린샷

- 성공
<img width="684" alt="스크린샷 2025-01-13 오후 11 07 31" src="https://github.com/user-attachments/assets/e8fc6e35-af3d-4818-9565-61327fc02863" />

-실패( 1보다 작은 페이지 수 입력)
<img width="701" alt="스크린샷 2025-01-13 오후 11 07 54" src="https://github.com/user-attachments/assets/757dde80-936c-4306-b158-0be0c30f1bc5" />
력)

-실패 (존재하지 않는 기록)
<img width="640" alt="스크린샷 2025-01-13 오후 11 08 20" src="https://github.com/user-attachments/assets/fe12700b-b544-4704-b69f-a927d0a8e56c" />


## ❗️리뷰어들께

- 응답 구조가 매우 복잡한 관계로 어쩔수 없이 DTO 구조가 난해한 부분이 있습니다.
- 위의 이유로 Converter에 Stream 로직의 가독성이 떨어질 수 있습니다.
- List<List<Comment>>를 이용한 부분이 있는데 List<Comment>를 클래스로 만들어줄까 하다가 하지 않았습니다. 
