### PR TITLE
[feat/#69] 옷 조회 API 관련 리팩토링

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
+++ b/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
@@ -1,12 +1,9 @@
 package com.clokey.server.domain.cloth.api;
 
 import com.clokey.server.domain.cloth.application.ClothService;
-import com.clokey.server.domain.cloth.converter.ClothConverter;
-import com.clokey.server.domain.model.repository.ClothRepository;
-import com.clokey.server.domain.cloth.dto.ClothResponseDto;
+import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 import com.clokey.server.domain.cloth.exception.annotation.ClothExist;
 import com.clokey.server.domain.cloth.exception.validator.ClothAccessibleValidator;
-import com.clokey.server.domain.model.entity.Cloth;
 import com.clokey.server.global.common.response.BaseResponse;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/clothes")
@@ -28,7 +23,6 @@ public class ClothRestController {
 
     private final ClothService clothService;
     private final ClothAccessibleValidator clothAccessibleValidator;
-    private final ClothRepository clothRepository;
 
     // 옷 상세 조회 API, 사용자 토큰 받는 부분 추가 및 변경해야함
     @GetMapping("/{clothId}")
@@ -39,14 +33,15 @@ public class ClothRestController {
     @Parameters({
             @Parameter(name = "clothId", description = "옷의 id, path variable 입니다.")
     })
-    public BaseResponse<ClothResponseDto.ClothReadResult> getClothDetails(@PathVariable @Valid @ClothExist Long clothId, @RequestParam Long memberId) {
+    public BaseResponse<ClothResponseDTO.ClothReadResult> getClothDetails(@PathVariable @Valid @ClothExist Long clothId, @RequestParam Long memberId) {
 
         // 멤버가 옷에 대해서 접근 권한이 있는지 확인합니다. -> 토큰을 이용해서 현재 로그인 중인 memberId 뽑아와서 넣어줄 것. 조회하는 현 유저를 나타냄
         clothAccessibleValidator.validateClothAccessOfMember(clothId, memberId);
 
-        Optional<Cloth> cloth = clothService.readClothById(clothId);
+        // ClothService를 통해 데이터를 가져오고, 결과 반환
+        ClothResponseDTO.ClothReadResult result = clothService.readClothDetailsById(clothId, memberId);
 
-        return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, ClothConverter.toClothReadResult(cloth.get()));
+        return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }
 
     // 옷 삭제 API, 사용자 토큰 받는 부분 추가 및 변경해야함
@@ -58,7 +53,7 @@ public class ClothRestController {
     @Parameters({
             @Parameter(name = "clothId", description = "옷의 id, path variable 입니다.")
     })
-    public BaseResponse<ClothResponseDto.ClothReadResult> deleteCloth(@PathVariable @Valid @ClothExist Long clothId, @RequestParam Long memberId) {
+    public BaseResponse<ClothResponseDTO.ClothReadResult> deleteCloth(@PathVariable @Valid @ClothExist Long clothId, @RequestParam Long memberId) {
 
         // 멤버가 옷에 대해서 수정 권한이 있는지 확인합니다. -> 토큰을 이용해서 현재 로그인 중인 memberId 뽑아와서 넣어줄 것. 삭제하는 현 유저를 나타냄
         clothAccessibleValidator.validateClothEditOfMember(clothId, memberId);

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
@@ -1,22 +1,12 @@
 package com.clokey.server.domain.cloth.application;
 
-import com.clokey.server.domain.cloth.dto.ClothRequestDto;
-import com.clokey.server.domain.cloth.dto.ClothResponseDto;
-import com.clokey.server.domain.model.entity.Cloth;
-import jakarta.validation.Valid;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Optional;
+import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 
 public interface ClothService {
 
-    boolean clothExist(Long clothId);
-
-    boolean isPublic(Long clothId);
-
     //public ClothResponseDto.ClothCreateResult createCloth(ClothRequestDto.ClothCreateRequest request, MultipartFile imageFile);
 
-    Optional<Cloth> readClothById(Long clothId);
+    ClothResponseDTO.ClothReadResult readClothDetailsById(Long clothId, Long memberId);
 
     void deleteClothById(Long clothId);
 }

--- a/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
+++ b/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
@@ -1,19 +1,16 @@
 package com.clokey.server.domain.cloth.converter;
 
-import com.clokey.server.domain.cloth.dto.ClothResponseDto;
+import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 import com.clokey.server.domain.model.entity.Cloth;
 import com.clokey.server.domain.model.entity.ClothImage;
-import com.clokey.server.domain.model.entity.enums.Season;
 
 import java.time.format.TextStyle;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 public class ClothConverter {
 
-    public static ClothResponseDto.ClothReadResult toClothReadResult(Cloth cloth) {
+    public static ClothResponseDTO.ClothReadResult toClothReadResult(Cloth cloth) {
 
         // CreatedAt으로 등록일자 가져오기 / LocalDateTime -> Date 변환
         Date regDate = java.sql.Date.valueOf(cloth.getCreatedAt().toLocalDate());
@@ -23,7 +20,7 @@ public class ClothConverter {
                 .getDisplayName(TextStyle.SHORT, Locale.ENGLISH)
                 .toUpperCase(); // 대문자로 출력
 
-        return ClothResponseDto.ClothReadResult.builder()
+        return ClothResponseDTO.ClothReadResult.builder()
                 .id(cloth.getId())
                 .name(cloth.getName())
                 .wearNum(cloth.getWearNum())

--- a/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
+++ b/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
@@ -3,18 +3,33 @@ package com.clokey.server.domain.cloth.converter;
 import com.clokey.server.domain.cloth.dto.ClothResponseDto;
 import com.clokey.server.domain.model.entity.Cloth;
 import com.clokey.server.domain.model.entity.ClothImage;
+import com.clokey.server.domain.model.entity.enums.Season;
 
+import java.time.format.TextStyle;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
 public class ClothConverter {
 
     public static ClothResponseDto.ClothReadResult toClothReadResult(Cloth cloth) {
+
+        // CreatedAt으로 등록일자 가져오기 / LocalDateTime -> Date 변환
+        Date regDate = java.sql.Date.valueOf(cloth.getCreatedAt().toLocalDate());
+
+        // 요일 가져오기
+        String dayOfWeek = cloth.getCreatedAt().getDayOfWeek()
+                .getDisplayName(TextStyle.SHORT, Locale.ENGLISH)
+                .toUpperCase(); // 대문자로 출력
+
         return ClothResponseDto.ClothReadResult.builder()
                 .id(cloth.getId())
                 .name(cloth.getName())
                 .wearNum(cloth.getWearNum())
-                .regDate(cloth.getRegDate())
-                .season(cloth.getSeason())
+                .regDate(regDate)
+                .dayOfWeek(dayOfWeek)
+                .seasons(cloth.getSeasons())
                 .tempUpperBound(cloth.getTempUpperBound())
                 .tempLowerBound(cloth.getTempLowerBound())
                 .thicknessLevel(cloth.getThicknessLevel())

--- a/src/main/java/com/clokey/server/domain/cloth/dto/ClothRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/cloth/dto/ClothRequestDTO.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-public class ClothRequestDto {
+public class ClothRequestDTO {
 
     @Builder
     @Getter

--- a/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
@@ -5,10 +5,10 @@ import com.clokey.server.domain.model.entity.enums.ThicknessLevel;
 import com.clokey.server.domain.model.entity.enums.Visibility;
 import lombok.*;
 
-import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 
-public class ClothResponseDto {
+public class ClothResponseDTO {
 
     @Builder
     @Getter
@@ -26,8 +26,9 @@ public class ClothResponseDto {
         Long id;
         String name;
         int wearNum;
-        LocalDate regDate;
-        Season season;
+        Date regDate;
+        String dayOfWeek;
+        List<Season> seasons;
         int tempUpperBound;
         int tempLowerBound;
         ThicknessLevel thicknessLevel;

--- a/src/main/java/com/clokey/server/domain/cloth/exception/ClothException.java
+++ b/src/main/java/com/clokey/server/domain/cloth/exception/ClothException.java
@@ -1,0 +1,11 @@
+package com.clokey.server.domain.cloth.exception;
+
+import com.clokey.server.global.error.code.BaseErrorCode;
+import com.clokey.server.global.error.exception.GeneralException;
+
+public class ClothException extends GeneralException {
+
+    public ClothException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/clokey/server/domain/cloth/exception/validator/ClothExistValidator.java
+++ b/src/main/java/com/clokey/server/domain/cloth/exception/validator/ClothExistValidator.java
@@ -2,6 +2,8 @@ package com.clokey.server.domain.cloth.exception.validator;
 
 import com.clokey.server.domain.cloth.application.ClothService;
 import com.clokey.server.domain.cloth.exception.annotation.ClothExist;
+import com.clokey.server.domain.model.entity.Cloth;
+import com.clokey.server.domain.model.repository.ClothRepository;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -11,11 +13,12 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ClothExistValidator implements ConstraintValidator<ClothExist, Long> {
-    private final ClothService clothService;
+
+    private final ClothRepository clothRepository;
 
     @Override
     public boolean isValid(Long clothId, ConstraintValidatorContext context) {
-        boolean isValid = clothService.clothExist(clothId);
+        boolean isValid = clothRepository.existsById(clothId);
 
         if (!isValid) {
             context.disableDefaultConstraintViolation();
@@ -23,6 +26,5 @@ public class ClothExistValidator implements ConstraintValidator<ClothExist, Long
         }
 
         return isValid;
-
     }
 }

--- a/src/main/java/com/clokey/server/domain/model/entity/Cloth.java
+++ b/src/main/java/com/clokey/server/domain/model/entity/Cloth.java
@@ -33,13 +33,14 @@ public class Cloth extends BaseEntity {
     @Column(nullable = false, columnDefinition = "integer default 0")
     private int wearNum;
 
-    @CreatedDate // 등록 날짜를 자동으로 기록
-    @Column(nullable = false, updatable = false)
-    private LocalDate regDate;
-
+    @ElementCollection(fetch = FetchType.LAZY) // 다중 값을 위한 설정
+    @CollectionTable(
+            name = "cloth_seasons", // 매핑될 계절 테이블 이름
+            joinColumns = @JoinColumn(name = "cloth_id") // 부모 테이블과의 조인 컬럼
+    )
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Season season;
+    @Column(name = "season", nullable = false) // 해당 season을 cloth_seasons 테이블에만 저장
+    private List<Season> seasons = new ArrayList<>();
 
     @Min(-20)
     @Max(40)
@@ -75,4 +76,8 @@ public class Cloth extends BaseEntity {
 
     @OneToMany(mappedBy = "cloth", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClothImage> images = new ArrayList<>();
+
+    public Long getMemberId() {
+        return this.member != null ? this.member.getId() : null;
+    }
 }

--- a/src/main/java/com/clokey/server/domain/model/repository/MemberRepository.java
+++ b/src/main/java/com/clokey/server/domain/model/repository/MemberRepository.java
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    @Override
+    Member getReferenceById(Long aLong);
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #69

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
Cloth 조회 관련 리팩토링

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
Cloth 조회 API 관련 수정사항
Cloth 엔티티에서 regDate 필드 삭제 후 createdAt을 통해서 등록일자 불러올 수 있도록 할 것
regDate에 따라서 요일도 리턴할 수 있도록 할 것
Cloth 엔티티에서 Season을 리스트로 여러개 관리해서 불러올 수 있도록 할 것
Cloth 서비스에서 에러 던지고 DatabaseException해주면 됨. Controller단에서 Optional하지 않기
Cloth 컨트롤러에서 컨버터 드러나지 않게 서비스로 옮겨줄 것
멤버 비공개 validator 추가
ClothException 추가

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
service단과 validator단의 메소드 분리 후 controller에서 어떻게 사용하는지 위주로 봐주시면 될 것 같습니다!
