### PR TITLE
[Feat/#82] 기록 추가 API 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
+++ b/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
@@ -81,7 +81,7 @@ public class ClothRestController {
             @RequestParam Long memberId
     ) {
         // 멤버가 옷에 대해서 수정 권한이 있는지 확인합니다. -> 토큰을 이용해서 현재 로그인 중인 memberId 뽑아와서 넣어줄 것. 삭제하는 현 유저를 나타냄
-        clothAccessibleValidator.validateClothEditOfMember(clothId, memberId);
+        clothAccessibleValidator.validateClothOfMember(clothId, memberId);
 
         // ClothService를 통해 데이터를 삭제
         clothService.deleteClothById(clothId);

--- a/src/main/java/com/clokey/server/domain/cloth/domain/entity/Cloth.java
+++ b/src/main/java/com/clokey/server/domain/cloth/domain/entity/Cloth.java
@@ -1,11 +1,13 @@
 package com.clokey.server.domain.cloth.domain.entity;
 
+import com.clokey.server.domain.cloth.exception.ClothException;
 import com.clokey.server.domain.model.entity.BaseEntity;
 import com.clokey.server.domain.category.domain.entity.Category;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.model.entity.enums.Season;
 import com.clokey.server.domain.model.entity.enums.ThicknessLevel;
 
+import com.clokey.server.global.error.code.status.ErrorStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -80,5 +82,15 @@ public class Cloth extends BaseEntity {
 
     public Long getMemberId() {
         return this.member != null ? this.member.getId() : null;
+    }
+
+    public void increaseWearNum() {
+        this.wearNum ++;
+    }
+
+    public void decreaseWearNum() {
+        if(wearNum == 0){
+            throw new ClothException(ErrorStatus.CLOTH_WEAR_NUM_BELOW_ZERO);
+        }
     }
 }

--- a/src/main/java/com/clokey/server/domain/cloth/domain/entity/Cloth.java
+++ b/src/main/java/com/clokey/server/domain/cloth/domain/entity/Cloth.java
@@ -92,5 +92,6 @@ public class Cloth extends BaseEntity {
         if(wearNum == 0){
             throw new ClothException(ErrorStatus.CLOTH_WEAR_NUM_BELOW_ZERO);
         }
+        this.wearNum--;
     }
 }

--- a/src/main/java/com/clokey/server/domain/cloth/exception/validator/ClothAccessibleValidator.java
+++ b/src/main/java/com/clokey/server/domain/cloth/exception/validator/ClothAccessibleValidator.java
@@ -5,10 +5,7 @@ import com.clokey.server.domain.cloth.exception.ClothException;
 import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.model.entity.enums.Visibility;
-import com.clokey.server.domain.cloth.domain.repository.ClothRepository;
-import com.clokey.server.domain.member.domain.repository.MemberRepository;
 import com.clokey.server.global.error.code.status.ErrorStatus;
-import com.clokey.server.global.error.exception.DatabaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -31,14 +28,14 @@ public class ClothAccessibleValidator {
         }
     }
 
-    public void validateClothEditOfMember(Long clothId, Long memberId) {
+    public void validateClothOfMember(Long clothId, Long memberId) {
         Cloth cloth = clothRepositoryService.findById(clothId);
 
-        //수정 권한 확인 - 나의 옷이 아닌 경우에 수정 불가.
+        //내 옷이 아닌지 확인
         boolean isNotMyCloth = !cloth.getMemberId().equals(memberId);
 
         if (isNotMyCloth) {
-            throw new ClothException(ErrorStatus.NO_PERMISSION_TO_EDIT_CLOTH);
+            throw new ClothException(ErrorStatus.NOT_MY_CLOTH);
         }
     }
 

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -142,7 +142,7 @@ public class HistoryRestController {
     })
     public BaseResponse<HistoryResponseDTO.HistoryCreateResult> postHistory(
             @RequestPart("historyCreateResult") @Valid HistoryRequestDTO.HistoryCreate historyCreateRequest,
-            @RequestPart("imageFile") MultipartFile imageFile,
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
             @RequestParam Long memberId
     ) {
 

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -145,7 +145,7 @@ public class HistoryRestController {
     })
     public BaseResponse<HistoryResponseDTO.HistoryCreateResult> postHistory(
             @RequestPart("historyCreateResult") @Valid HistoryRequestDTO.HistoryCreate historyCreateRequest,
-            @RequestPart(value = "imageFile", required = false) @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
+            @RequestPart(value = "imageFile", required = false) @Valid @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
             @RequestParam Long memberId
     ) {
 

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -7,6 +7,7 @@ import com.clokey.server.domain.history.dto.HistoryRequestDTO;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
 import com.clokey.server.domain.history.exception.annotation.CheckPage;
 import com.clokey.server.domain.history.exception.annotation.HistoryExist;
+import com.clokey.server.domain.history.exception.annotation.HistoryImageQuantityLimit;
 import com.clokey.server.domain.history.exception.annotation.MonthFormat;
 import com.clokey.server.domain.history.exception.validator.CommentValidator;
 import com.clokey.server.domain.history.exception.validator.HistoryAccessibleValidator;
@@ -25,6 +26,8 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -142,11 +145,11 @@ public class HistoryRestController {
     })
     public BaseResponse<HistoryResponseDTO.HistoryCreateResult> postHistory(
             @RequestPart("historyCreateResult") @Valid HistoryRequestDTO.HistoryCreate historyCreateRequest,
-            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
+            @RequestPart(value = "imageFile", required = false) @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
             @RequestParam Long memberId
     ) {
 
-        HistoryResponseDTO.HistoryCreateResult result = historyService.createHistory(historyCreateRequest, memberId, imageFile);
+        HistoryResponseDTO.HistoryCreateResult result = historyService.createHistory(historyCreateRequest, memberId, imageFiles);
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_CREATED, result);
     }

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -1,5 +1,7 @@
 package com.clokey.server.domain.history.api;
 
+import com.clokey.server.domain.cloth.dto.ClothRequestDTO;
+import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 import com.clokey.server.domain.history.application.HistoryService;
 import com.clokey.server.domain.history.dto.HistoryRequestDTO;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
@@ -18,8 +20,10 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -88,7 +92,7 @@ public class HistoryRestController {
     public BaseResponse<HistoryResponseDTO.HistoryCommentResult> getComments(@PathVariable @Valid @HistoryExist Long historyId,
                                                                              @RequestParam(value = "page") @Valid @CheckPage int page) {
         //페이지를 1에서 부터 받기 위해서 -1을 해서 입력합니다.
-        HistoryResponseDTO.HistoryCommentResult result = historyService.getComments(historyId, page-1);
+        HistoryResponseDTO.HistoryCommentResult result = historyService.getComments(historyId, page - 1);
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_SUCCESS, result);
     }
@@ -127,5 +131,22 @@ public class HistoryRestController {
         commentValidator.validateParentCommentHistory(historyId, request.getCommentId());
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_COMMENT_CREATED, historyService.writeComment(historyId, request.getCommentId(), thisMemberId, request.getContent()));
 
+    }
+
+    //임시로 토큰을 request param으로 받는중.
+    @PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "새로운 기록을 생성하는 API", description = "request body에 HistoryCreateRequestDTO 형식의 데이터를 전달해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_201", description = "CREATED, 성공적으로 생성되었습니다."),
+    })
+    public BaseResponse<HistoryResponseDTO.HistoryCreateResult> postHistory(
+            @RequestPart("historyCreateResult") @Valid HistoryRequestDTO.HistoryCreate historyCreateRequest,
+            @RequestPart("imageFile") MultipartFile imageFile,
+            @RequestParam Long memberId
+    ) {
+
+        HistoryResponseDTO.HistoryCreateResult result = historyService.createHistory(historyCreateRequest, memberId, imageFile);
+
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_CREATED, result);
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -10,6 +10,7 @@ import com.clokey.server.domain.history.exception.annotation.HistoryExist;
 import com.clokey.server.domain.history.exception.annotation.MonthFormat;
 import com.clokey.server.domain.history.exception.validator.CommentValidator;
 import com.clokey.server.domain.history.exception.validator.HistoryAccessibleValidator;
+import com.clokey.server.domain.history.exception.validator.HistoryAlreadyExistValidator;
 import com.clokey.server.domain.history.exception.validator.HistoryLikedValidator;
 import com.clokey.server.domain.member.exception.annotation.MemberExist;
 import com.clokey.server.global.common.response.BaseResponse;

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
@@ -9,4 +9,6 @@ public interface HashtagHistoryRepositoryService {
     boolean existsByHistory_Id(Long historyId);
 
     List<HashtagHistory> findByHistory_Id(Long historyId);
+
+    void save(HashtagHistory hashtagHistory);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
@@ -25,4 +25,9 @@ public class HashtagHistoryRepositoryServiceImpl implements HashtagHistoryReposi
     public List<HashtagHistory> findByHistory_Id(Long historyId) {
         return hashtagHistoryRepository.findByHistory_Id(historyId);
     }
+
+    @Override
+    public void save(HashtagHistory hashtagHistory) {
+        hashtagHistoryRepository.save(hashtagHistory);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryService.java
@@ -1,0 +1,10 @@
+package com.clokey.server.domain.history.application;
+
+import com.clokey.server.domain.history.domain.entity.Hashtag;
+
+public interface HashtagRepositoryService {
+
+    boolean existByName(String name);
+
+    Hashtag findByName(String name);
+}

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryService.java
@@ -7,4 +7,6 @@ public interface HashtagRepositoryService {
     boolean existByName(String name);
 
     Hashtag findByName(String name);
+
+    void save(Hashtag hashtag);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryServiceImpl.java
@@ -24,4 +24,9 @@ public class HashtagRepositoryServiceImpl implements HashtagRepositoryService{
     public Hashtag findByName(String name) {
         return hashtagRepository.findByName(name).orElseThrow(()-> new HashtagException(ErrorStatus.NO_SUCH_HASHTAG_NAME));
     }
+
+    @Override
+    public void save(Hashtag hashtag) {
+        hashtagRepository.save(hashtag);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagRepositoryServiceImpl.java
@@ -1,0 +1,27 @@
+package com.clokey.server.domain.history.application;
+
+import com.clokey.server.domain.history.domain.entity.Hashtag;
+import com.clokey.server.domain.history.domain.repository.HashtagRepository;
+import com.clokey.server.domain.history.exception.HashtagException;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class HashtagRepositoryServiceImpl implements HashtagRepositoryService{
+
+    private final HashtagRepository hashtagRepository;
+
+    @Override
+    public boolean existByName(String name) {
+        return hashtagRepository.findByName(name).isPresent();
+    }
+
+    @Override
+    public Hashtag findByName(String name) {
+        return hashtagRepository.findByName(name).orElseThrow(()-> new HashtagException(ErrorStatus.NO_SUCH_HASHTAG_NAME));
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
@@ -1,0 +1,9 @@
+package com.clokey.server.domain.history.application;
+
+import com.clokey.server.domain.history.domain.entity.HistoryCloth;
+
+public interface HistoryClothRepositoryService {
+
+    void save(HistoryCloth historyCloth);
+
+}

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
@@ -1,0 +1,20 @@
+package com.clokey.server.domain.history.application;
+
+import com.clokey.server.domain.history.domain.entity.HistoryCloth;
+import com.clokey.server.domain.history.domain.repository.HistoryClothRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class HistoryClothRepositoryServiceImpl implements HistoryClothRepositoryService{
+
+    private final HistoryClothRepository historyClothRepository;
+
+    @Override
+    public void save(HistoryCloth historyCloth) {
+        historyClothRepository.save(historyCloth);
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
@@ -10,4 +10,6 @@ public interface HistoryImageRepositoryService {
 
     List<HistoryImage> findByHistory_Id(Long historyId);
 
+    HistoryImage save(HistoryImage historyImage);
+
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
@@ -25,4 +25,9 @@ public class HistoryImageRepositoryServiceImpl implements HistoryImageRepository
     public List<HistoryImage> findByHistory_Id(Long historyId) {
         return findByHistory_Id(historyId);
     }
+
+    @Override
+    public HistoryImage save(HistoryImage historyImage) {
+        return historyImageRepository.save(historyImage);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -2,6 +2,7 @@ package com.clokey.server.domain.history.application;
 
 import com.clokey.server.domain.history.domain.entity.History;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface HistoryRepositoryService {
@@ -17,4 +18,6 @@ public interface HistoryRepositoryService {
     boolean existsById(Long historyId);
 
     History save(History history);
+
+    boolean checkHistoryExistOfDate(LocalDate date, Long memberId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -16,5 +16,5 @@ public interface HistoryRepositoryService {
 
     boolean existsById(Long historyId);
 
-    void save(History history);
+    History save(History history);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -15,4 +15,6 @@ public interface HistoryRepositoryService {
     History findById(Long historyId);
 
     boolean existsById(Long historyId);
+
+    void save(History history);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
@@ -43,4 +43,9 @@ public class HistoryRepositoryServiceImpl implements HistoryRepositoryService {
     public boolean existsById(Long historyId) {
         return historyRepository.existsById(historyId);
     }
+
+    @Override
+    public void save(History history) {
+        historyRepository.save(history);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -47,5 +48,10 @@ public class HistoryRepositoryServiceImpl implements HistoryRepositoryService {
     @Override
     public History save(History history) {
         return historyRepository.save(history);
+    }
+
+    @Override
+    public boolean checkHistoryExistOfDate(LocalDate date, Long memberId) {
+        return historyRepository.existsByHistoryDateAndMember_Id(date,memberId);
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
@@ -45,7 +45,7 @@ public class HistoryRepositoryServiceImpl implements HistoryRepositoryService {
     }
 
     @Override
-    public void save(History history) {
-        historyRepository.save(history);
+    public History save(History history) {
+        return historyRepository.save(history);
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
@@ -1,6 +1,8 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.history.dto.HistoryRequestDTO;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface HistoryService {
 
@@ -13,5 +15,7 @@ public interface HistoryService {
     HistoryResponseDTO.HistoryCommentResult getComments(Long historyId, int page);
 
     HistoryResponseDTO.MonthViewResult getMonthlyHistories(Long this_member_id, Long memberId, String month);
+
+    HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest, Long memberId,MultipartFile image);
 
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
@@ -4,6 +4,8 @@ import com.clokey.server.domain.history.dto.HistoryRequestDTO;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface HistoryService {
 
     HistoryResponseDTO.LikeResult changeLike(Long memberId, Long historyId, boolean isLiked);
@@ -16,6 +18,6 @@ public interface HistoryService {
 
     HistoryResponseDTO.MonthViewResult getMonthlyHistories(Long this_member_id, Long memberId, String month);
 
-    HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest, Long memberId,MultipartFile image);
+    HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest, Long memberId, List<MultipartFile> images);
 
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -9,6 +9,7 @@ import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.entity.HistoryImage;
 import com.clokey.server.domain.history.domain.repository.*;
 import com.clokey.server.domain.history.dto.HistoryRequestDTO;
+import com.clokey.server.domain.history.exception.validator.HistoryAlreadyExistValidator;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.history.domain.entity.HashtagHistory;
@@ -30,6 +31,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HistoryServiceImpl implements HistoryService{
 
+    private final HistoryAlreadyExistValidator historyAlreadyExistValidator;
     private final HistoryRepositoryService historyRepositoryService;
     private final CommentRepositoryService commentRepositoryService;
     private final MemberRepositoryService memberRepositoryService;
@@ -134,6 +136,8 @@ public class HistoryServiceImpl implements HistoryService{
 
     @Override
     public HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest,Long memberId, MultipartFile imageFile) {
+
+        historyAlreadyExistValidator.validate(memberId,historyCreateRequest.getDate());
 
         // History 엔티티 생성 후 요청 정보 반환해서 저장
         History history = historyRepositoryService.save(HistoryConverter.toHistory(historyCreateRequest, memberRepositoryService.findMemberById(memberId)));

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.cloth.application.ClothRepositoryService;
 import com.clokey.server.domain.cloth.converter.ClothConverter;
 import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.cloth.domain.entity.ClothImage;
@@ -39,6 +40,7 @@ public class HistoryServiceImpl implements HistoryService{
     private final HistoryImageRepositoryService historyImageRepositoryService;
     private final HashtagHistoryRepositoryService hashtagHistoryRepositoryService;
     private final S3ImageService s3ImageService;
+    private final ClothRepositoryService clothRepositoryService;
 
     @Override
     public HistoryResponseDTO.LikeResult changeLike(Long memberId, Long historyId, boolean isLiked) {
@@ -150,6 +152,10 @@ public class HistoryServiceImpl implements HistoryService{
                 .imageUrl(imageUrl)
                 .history(history)
                 .build();
+
+        //모든 옷의 착용횟수를 1올려줍니다.
+        historyCreateRequest.getClothes()
+                .forEach(clothId-> clothRepositoryService.findById(clothId).increaseWearNum());
 
         // HistoryImage 저장
         historyImageRepositoryService.save(historyImage);

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -1,11 +1,15 @@
 package com.clokey.server.domain.history.converter;
 
+import com.clokey.server.domain.history.dto.HistoryRequestDTO;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
 import com.clokey.server.domain.history.domain.entity.Comment;
 import com.clokey.server.domain.history.domain.entity.History;
+import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.model.entity.enums.Visibility;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -126,6 +130,19 @@ public class HistoryConverter {
     public static HistoryResponseDTO.CommentWriteResult toCommentWriteResult(Comment comment){
         return HistoryResponseDTO.CommentWriteResult.builder()
                 .commentId(comment.getId())
+                .build();
+    }
+
+    public static History toHistory(HistoryRequestDTO.HistoryCreate request, Member member) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd"); // 패턴 지정
+
+        return History.builder()
+                .historyDate(LocalDate.parse(request.getDate(),formatter))
+                .likes(0)
+                .visibility(request.getVisibility())
+                .content(request.getContent())
+                .member(member)
                 .build();
     }
 

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -146,6 +146,12 @@ public class HistoryConverter {
                 .build();
     }
 
+    public static HistoryResponseDTO.HistoryCreateResult historyCreateResult(History history){
+        return HistoryResponseDTO.HistoryCreateResult.builder()
+                .historyId(history.getId())
+                .build();
+    }
+
 
 
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagRepository.java
@@ -3,5 +3,10 @@ package com.clokey.server.domain.history.domain.repository;
 import com.clokey.server.domain.history.domain.entity.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+
+    Optional<Hashtag> findByName(String name);
+
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
@@ -19,4 +20,6 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
 
     @Query("UPDATE History h SET h.likes = h.likes - 1 WHERE h.id = :historyId")
     void decrementLikes(Long historyId);
+
+    boolean existsByHistoryDateAndMember_Id(LocalDate historyDate, Long memberId);
 }

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -25,6 +25,7 @@ public class HistoryRequestDTO {
         @UniqueClothes
         List<Long> clothes;
 
+        @UniqueHashtags
         List<String> hashtags;
 
         Visibility visibility;

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -3,6 +3,7 @@ package com.clokey.server.domain.history.dto;
 import com.clokey.server.domain.history.exception.annotation.ContentLength;
 import com.clokey.server.domain.history.exception.annotation.HistoryExist;
 import com.clokey.server.domain.history.exception.annotation.ParentCommentConditions;
+import com.clokey.server.domain.model.entity.enums.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -10,7 +11,27 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class HistoryRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HistoryCreate {
+
+        String content;
+
+        List<Long> clothes;
+
+        List<String> hashtags;
+
+        Visibility visibility;
+
+        String date;
+    }
+
 
     @Builder
     @Getter

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -1,6 +1,6 @@
 package com.clokey.server.domain.history.dto;
 
-import com.clokey.server.domain.history.exception.annotation.ContentLength;
+import com.clokey.server.domain.history.exception.annotation.CommentContentLength;
 import com.clokey.server.domain.history.exception.annotation.HistoryExist;
 import com.clokey.server.domain.history.exception.annotation.ParentCommentConditions;
 import com.clokey.server.domain.model.entity.enums.Visibility;
@@ -56,7 +56,7 @@ public class HistoryRequestDTO {
         @ParentCommentConditions
         Long commentId;
 
-        @ContentLength
+        @CommentContentLength
         @NotBlank
         String content;
     }

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -29,6 +29,7 @@ public class HistoryRequestDTO {
 
         Visibility visibility;
 
+        @HistoryDateFormat
         String date;
     }
 

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -1,8 +1,6 @@
 package com.clokey.server.domain.history.dto;
 
-import com.clokey.server.domain.history.exception.annotation.CommentContentLength;
-import com.clokey.server.domain.history.exception.annotation.HistoryExist;
-import com.clokey.server.domain.history.exception.annotation.ParentCommentConditions;
+import com.clokey.server.domain.history.exception.annotation.*;
 import com.clokey.server.domain.model.entity.enums.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
@@ -21,8 +19,10 @@ public class HistoryRequestDTO {
     @AllArgsConstructor
     public static class HistoryCreate {
 
+        @HistoryContentLength
         String content;
 
+        @UniqueClothes
         List<Long> clothes;
 
         List<String> hashtags;

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDTO.java
@@ -100,6 +100,14 @@ public class HistoryResponseDTO {
         Long commentId;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HistoryCreateResult{
+        Long historyId;
+    }
+
 }
 
 

--- a/src/main/java/com/clokey/server/domain/history/exception/HashtagException.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/HashtagException.java
@@ -1,0 +1,11 @@
+package com.clokey.server.domain.history.exception;
+
+import com.clokey.server.global.error.code.BaseErrorCode;
+import com.clokey.server.global.error.exception.GeneralException;
+
+public class HashtagException extends GeneralException {
+
+    public HashtagException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/HistoryException.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/HistoryException.java
@@ -1,0 +1,11 @@
+package com.clokey.server.domain.history.exception;
+
+import com.clokey.server.global.error.code.BaseErrorCode;
+import com.clokey.server.global.error.exception.GeneralException;
+
+public class HistoryException extends GeneralException {
+
+    public HistoryException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/CommentContentLength.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/CommentContentLength.java
@@ -1,6 +1,5 @@
 package com.clokey.server.domain.history.exception.annotation;
 
-import com.clokey.server.domain.history.exception.validator.CheckPageValidator;
 import com.clokey.server.domain.history.exception.validator.ContentLengthValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
@@ -11,7 +10,7 @@ import java.lang.annotation.*;
 @Constraint(validatedBy = ContentLengthValidator.class)
 @Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ContentLength {
+public @interface CommentContentLength {
 
     String message() default "댓글의 길이는 50자를 넘어가서는 안됍니다.";
     Class<?>[] groups() default {};

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryContentLength.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryContentLength.java
@@ -1,18 +1,18 @@
 package com.clokey.server.domain.history.exception.annotation;
 
-import com.clokey.server.domain.history.exception.validator.CommentContentLengthValidator;
+import com.clokey.server.domain.history.exception.validator.HistoryContentLengthValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 import java.lang.annotation.*;
 
 @Documented
-@Constraint(validatedBy = CommentContentLengthValidator.class)
+@Constraint(validatedBy = HistoryContentLengthValidator.class)
 @Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CommentContentLength {
+public @interface HistoryContentLength {
 
-    String message() default "댓글의 길이는 50자를 넘어가서는 안됍니다.";
+    String message() default "기록의 내용은 200자를 넘어가서는 안됍니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryDateFormat.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryDateFormat.java
@@ -1,0 +1,18 @@
+package com.clokey.server.domain.history.exception.annotation;
+
+import com.clokey.server.domain.history.exception.validator.HistoryDateFormatValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = HistoryDateFormatValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HistoryDateFormat {
+
+    String message() default "기록의 날짜 형식이 올바르지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryImageQuantityLimit.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/HistoryImageQuantityLimit.java
@@ -1,0 +1,18 @@
+package com.clokey.server.domain.history.exception.annotation;
+
+import com.clokey.server.domain.history.exception.validator.HistoryImageQuantityLimitValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = HistoryImageQuantityLimitValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HistoryImageQuantityLimit{
+
+    String message() default "기록 사진을 10개 이상 등록할 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/UniqueClothes.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/UniqueClothes.java
@@ -1,0 +1,18 @@
+package com.clokey.server.domain.history.exception.annotation;
+
+import com.clokey.server.domain.history.exception.validator.UniqueClothesValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UniqueClothesValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueClothes {
+
+    String message() default "중복된 옷이 존재합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/annotation/UniqueHashtags.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/annotation/UniqueHashtags.java
@@ -1,0 +1,19 @@
+package com.clokey.server.domain.history.exception.annotation;
+
+import com.clokey.server.domain.history.exception.validator.UniqueClothesValidator;
+import com.clokey.server.domain.history.exception.validator.UniqueHashtagsValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UniqueHashtagsValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueHashtags {
+
+    String message() default "중복된 해시태그가 존재합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/CommentContentLengthValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/CommentContentLengthValidator.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ContentLengthValidator implements ConstraintValidator<CommentContentLength, String> {
+public class CommentContentLengthValidator implements ConstraintValidator<CommentContentLength, String> {
 
     @Override
     public void initialize(CommentContentLength constraintAnnotation) {

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/ContentLengthValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/ContentLengthValidator.java
@@ -1,7 +1,6 @@
 package com.clokey.server.domain.history.exception.validator;
 
-import com.clokey.server.domain.history.exception.annotation.CheckPage;
-import com.clokey.server.domain.history.exception.annotation.ContentLength;
+import com.clokey.server.domain.history.exception.annotation.CommentContentLength;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -10,10 +9,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ContentLengthValidator implements ConstraintValidator<ContentLength, String> {
+public class ContentLengthValidator implements ConstraintValidator<CommentContentLength, String> {
 
     @Override
-    public void initialize(ContentLength constraintAnnotation) {
+    public void initialize(CommentContentLength constraintAnnotation) {
         ConstraintValidator.super.initialize(constraintAnnotation);
     }
 

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryAlreadyExistValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryAlreadyExistValidator.java
@@ -1,0 +1,26 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.history.application.HistoryRepositoryService;
+import com.clokey.server.domain.history.exception.HistoryException;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class HistoryAlreadyExistValidator {
+
+    private final HistoryRepositoryService historyRepositoryService;
+
+    public void validate(Long memberId, String date){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        boolean isNotValid = historyRepositoryService.checkHistoryExistOfDate(LocalDate.parse(date, formatter),memberId);
+
+        if(isNotValid) {
+            throw new HistoryException(ErrorStatus.HISTORY_ALREADY_EXIST_FOR_DATE);
+        }
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryContentLengthValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryContentLengthValidator.java
@@ -1,0 +1,32 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.history.exception.annotation.CommentContentLength;
+import com.clokey.server.domain.history.exception.annotation.HistoryContentLength;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HistoryContentLengthValidator implements ConstraintValidator<HistoryContentLength, String> {
+
+    @Override
+    public void initialize(HistoryContentLength constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String content, ConstraintValidatorContext context) {
+        boolean isValid = content.length() <= 200;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.HISTORY_CONTENT_OUT_OF_RANGE.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryDateFormatValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryDateFormatValidator.java
@@ -1,0 +1,36 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.history.exception.annotation.HistoryDateFormat;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HistoryDateFormatValidator implements ConstraintValidator<HistoryDateFormat, String> {
+
+    //YYYY-MM-dd에 대한 정규 표현식.
+    private static final String DATE_PATTERN = "\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])";
+
+    @Override
+    public void initialize(HistoryDateFormat constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+
+        //null이나 빈값이 아니며 YYYY-MM 형태를 만족해야 한다.
+        boolean isValid = value!=null && !value.isEmpty() && value.matches(DATE_PATTERN);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.DATE_INVALID.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}
+

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryImageQuantityLimitValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryImageQuantityLimitValidator.java
@@ -25,6 +25,11 @@ public class HistoryImageQuantityLimitValidator implements ConstraintValidator<H
 
     @Override
     public boolean isValid(List<MultipartFile> images, ConstraintValidatorContext context) {
+
+        if(images == null || images.isEmpty()){
+            return true;
+        }
+
         boolean isValid = images.size()<=10;
 
         if (!isValid) {

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryImageQuantityLimitValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryImageQuantityLimitValidator.java
@@ -1,0 +1,39 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.history.application.HistoryRepositoryService;
+import com.clokey.server.domain.history.exception.annotation.HistoryExist;
+import com.clokey.server.domain.history.exception.annotation.HistoryImageQuantityLimit;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class HistoryImageQuantityLimitValidator implements ConstraintValidator<HistoryImageQuantityLimit, List<MultipartFile>> {
+
+    private final HistoryRepositoryService historyRepositoryService;
+
+    @Override
+    public void initialize(HistoryImageQuantityLimit constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<MultipartFile> images, ConstraintValidatorContext context) {
+        boolean isValid = images.size()<=10;
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.IMAGE_QUANTITY_OVER_HISTORY_IMAGE_LIMIT.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}
+

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/UniqueClothesValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/UniqueClothesValidator.java
@@ -1,0 +1,42 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.history.exception.annotation.CheckPage;
+import com.clokey.server.domain.history.exception.annotation.UniqueClothes;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class UniqueClothesValidator implements ConstraintValidator<UniqueClothes, List<Long>> {
+
+    @Override
+    public void initialize(UniqueClothes constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<Long> clothes, ConstraintValidatorContext context) {
+
+        if (clothes == null || clothes.isEmpty()) {
+            return true; // 비어있는 경우는 유효하다고 판단
+        }
+
+        Set<Long> uniqueClothes = new HashSet<>(clothes); // Set에 리스트를 추가
+        boolean isValid = uniqueClothes.size() == clothes.size();
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.DUPLICATE_CLOTHES_FOR_HISTORY.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/UniqueHashtagsValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/UniqueHashtagsValidator.java
@@ -1,0 +1,42 @@
+package com.clokey.server.domain.history.exception.validator;
+
+import com.clokey.server.domain.history.exception.annotation.CheckPage;
+import com.clokey.server.domain.history.exception.annotation.UniqueHashtags;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class UniqueHashtagsValidator implements ConstraintValidator<UniqueHashtags, List<String>> {
+
+    @Override
+    public void initialize(UniqueHashtags constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<String> hashtags, ConstraintValidatorContext context) {
+
+        if (hashtags == null || hashtags.isEmpty()) {
+            return true; // 비어있는 경우는 유효하다고 판단
+        }
+
+        Set<String> uniqueHashtags = new HashSet<>(hashtags); // Set에 리스트를 추가
+        boolean isValid = uniqueHashtags.size() == hashtags.size();
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.DUPLICATE_HASHTAGS.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+
+    }
+}

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -54,6 +54,7 @@ public enum ErrorStatus implements BaseErrorCode {
     COMMENT_LENGTH_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"HISTORY_4007","댓글은 빈칸이 아닌 50자 이하여야 합니다."),
     NESTED_COMMENT(HttpStatus.BAD_REQUEST,"HISTORY_4008","대댓글에 답장을 남길 수 없습니다."),
     PARENT_COMMENT_HISTORY_ERROR(HttpStatus.BAD_REQUEST,"HISTORY_4009","부모 댓글의 기록과 작성하는 댓글의 기록이 일치하지 않습니다."),
+    HISTORY_CONTENT_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"HISTORY_4010","기록의 내용은 200자 이하여야 합니다."),
 
     //알림 에러
     NOTIFICATION_TYPE_INVALID(HttpStatus.BAD_REQUEST,"NOTIFICATION_4001","잘못된 알림 Type 입니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -58,6 +58,7 @@ public enum ErrorStatus implements BaseErrorCode {
     HISTORY_CONTENT_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"HISTORY_4010","기록의 내용은 200자 이하여야 합니다."),
     DUPLICATE_CLOTHES_FOR_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4011","기록에 중복된 옷을 등록할 수 없습니다"),
     HISTORY_ALREADY_EXIST_FOR_DATE(HttpStatus.BAD_REQUEST,"HISTORY_4012","이미 기록이 존재하는 날짜입니다."),
+    IMAGE_QUANTITY_OVER_HISTORY_IMAGE_LIMIT(HttpStatus.BAD_REQUEST,"HISTORY_4013","사진을 10개 넘게 업로드 할 수 없습니다."),
 
     //해시태그 에러
     NO_SUCH_HASHTAG_NAME(HttpStatus.BAD_REQUEST,"HASHTAG_4001","해당 이름의 해시태그가 존재하지 않습니다"),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CLOTH_TEMP_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"CLOTH_4005","옷의 상한 또는 하한 온도가 범위를 벗어났습니다"),
     CLOTH_TEMP_ORDER_INVALID(HttpStatus.BAD_REQUEST,"CLOTH_4006","옷의 하한 온도가 상한 온도보다 높습니다."),
     CLOTH_THICKNESS_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"CLOTH_4005","옷의 두께가 범위를 벗어났습니다."),
+    CLOTH_WEAR_NUM_BELOW_ZERO(HttpStatus.BAD_REQUEST,"CLOTH_4006","옷의 착용 횟수를 0아래로 내릴 수 없습니다"),
 
     //폴더 에러
     NO_SUCH_FOLDER(HttpStatus.NOT_FOUND,"FOLDER_4041","존재하지 않는 폴더 ID입니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -29,7 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //옷 에러
     NO_SUCH_CLOTH(HttpStatus.NOT_FOUND,"CLOTH_4041","존재하지 않는 옷 ID입니다."),
     NO_PERMISSION_TO_ACCESS_CLOTH(HttpStatus.BAD_REQUEST,"CLOTH_4002","옷에 대한 접근 권한이 없습니다."),
-    NO_PERMISSION_TO_EDIT_CLOTH(HttpStatus.BAD_REQUEST,"CLOTH_4003","옷에 대한 수정 권한이 없습니다"),
+    NOT_MY_CLOTH(HttpStatus.BAD_REQUEST,"CLOTH_4003","나의 옷이 아닙니다."),
     CLOTH_VISIBILITY_INVALID(HttpStatus.BAD_REQUEST,"CLOTH_4004","잘못된 visibility 값을 입력했습니다"),
     CLOTH_TEMP_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"CLOTH_4005","옷의 상한 또는 하한 온도가 범위를 벗어났습니다"),
     CLOTH_TEMP_ORDER_INVALID(HttpStatus.BAD_REQUEST,"CLOTH_4006","옷의 하한 온도가 상한 온도보다 높습니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //해시태그 에러
     NO_SUCH_HASHTAG_NAME(HttpStatus.BAD_REQUEST,"HASHTAG_4001","해당 이름의 해시태그가 존재하지 않습니다"),
+    DUPLICATE_HASHTAGS(HttpStatus.BAD_REQUEST,"HASHTAG_4002","중복된 해시태그를 기록에 등록할 수 없습니다"),
 
     //알림 에러
     NOTIFICATION_TYPE_INVALID(HttpStatus.BAD_REQUEST,"NOTIFICATION_4001","잘못된 알림 Type 입니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -59,6 +59,9 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_CLOTHES_FOR_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4011","기록에 중복된 옷을 등록할 수 없습니다"),
     HISTORY_ALREADY_EXIST_FOR_DATE(HttpStatus.BAD_REQUEST,"HISTORY_4012","이미 기록이 존재하는 날짜입니다."),
 
+    //해시태그 에러
+    NO_SUCH_HASHTAG_NAME(HttpStatus.BAD_REQUEST,"HASHTAG_4001","해당 이름의 해시태그가 존재하지 않습니다"),
+
     //알림 에러
     NOTIFICATION_TYPE_INVALID(HttpStatus.BAD_REQUEST,"NOTIFICATION_4001","잘못된 알림 Type 입니다."),
 

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -55,6 +55,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NESTED_COMMENT(HttpStatus.BAD_REQUEST,"HISTORY_4008","대댓글에 답장을 남길 수 없습니다."),
     PARENT_COMMENT_HISTORY_ERROR(HttpStatus.BAD_REQUEST,"HISTORY_4009","부모 댓글의 기록과 작성하는 댓글의 기록이 일치하지 않습니다."),
     HISTORY_CONTENT_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"HISTORY_4010","기록의 내용은 200자 이하여야 합니다."),
+    DUPLICATE_CLOTHES_FOR_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4011","기록에 중복된 옷을 등록할 수 없습니다"),
 
     //알림 에러
     NOTIFICATION_TYPE_INVALID(HttpStatus.BAD_REQUEST,"NOTIFICATION_4001","잘못된 알림 Type 입니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -56,6 +56,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PARENT_COMMENT_HISTORY_ERROR(HttpStatus.BAD_REQUEST,"HISTORY_4009","부모 댓글의 기록과 작성하는 댓글의 기록이 일치하지 않습니다."),
     HISTORY_CONTENT_OUT_OF_RANGE(HttpStatus.BAD_REQUEST,"HISTORY_4010","기록의 내용은 200자 이하여야 합니다."),
     DUPLICATE_CLOTHES_FOR_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4011","기록에 중복된 옷을 등록할 수 없습니다"),
+    HISTORY_ALREADY_EXIST_FOR_DATE(HttpStatus.BAD_REQUEST,"HISTORY_4012","이미 기록이 존재하는 날짜입니다."),
 
     //알림 에러
     NOTIFICATION_TYPE_INVALID(HttpStatus.BAD_REQUEST,"NOTIFICATION_4001","잘못된 알림 Type 입니다."),


### PR DESCRIPTION
## 📌 연관 이슈
- close #82 

## 🌱 PR 요약
- 기록을 추가하는 API

## 🛠 작업 내용

### 기능 
- 해당 날짜에 기록 추가 api입니다.
- 임시로 MemberId는 Path_variable로 받습니다. 
- 기록이 되는 동시에 기록에 속한 옷의 wearNum(착용횟수)을 늘려야 하는 기능이 포함되어 있습니다. -> 해당 매서드는 옷 엔티티에 추가.
- 존재하는 해시태그일 경우 새로운 해시태그를 생성하지 않고 hashtag_history 테이블에 추가됩니다.
- 존재하지 않는 해시태그일 경우 새로운 해시태그를 생성하고 hashtag_history 테이블에 추가됩니다.
- 최대 10개까지의 사진을 업로드할 수 있습니다. 대표 사진은 첫 번째 사진으로 조회 API에서 첫 번째 사진을 조회합니다.
- 기록-옷 매핑 테이블에 등록된 옷이 추가됩니다

### 예외

- 옷이 나의 옷이 아닌 경우

- 존재하지 않는 날짜 ex) 2025-2-31  또는 날짜 형식에 맞지 않는 경우.

- 이미 유저가 기록을 한 날짜면 에러가 난다→ 수정 API를 이용해주세요.

- 같은 옷이 두번 -> clothes List가 unique하지 않다. 

- content가 200자를 넘어가는 경우 (DB 제약 조건).

- 중복된 해시태그 -> hashtag List가 unique 하지 않다. 

## 📸 스크린샷

- 성공한 경우
<img width="1016" alt="스크린샷 2025-01-25 오후 8 15 43" src="https://github.com/user-attachments/assets/a8f1eeb8-fe94-457a-b52f-281d53e2c300" />

-나의 옷이 아닌 경우
<img width="702" alt="스크린샷 2025-01-25 오후 8 23 22" src="https://github.com/user-attachments/assets/b1c24a8c-e2ee-4386-8cde-4a7e67aee5dd" />

-날짜의 형식이 맞지 않거나 존재 하지 않는 날짜
<img width="702" alt="스크린샷 2025-01-25 오후 8 24 34" src="https://github.com/user-attachments/assets/9be560c4-c4ca-4968-8b51-85bc3a469ab2" />

- 중복된 옷을 등록 
<img width="702" alt="스크린샷 2025-01-25 오후 8 24 48" src="https://github.com/user-attachments/assets/bfff24fc-6efe-41dd-bf37-f636953145a8" />

- 내용이 200자를 넘어가는 경우
<img width="702" alt="스크린샷 2025-01-25 오후 8 27 51" src="https://github.com/user-attachments/assets/64240136-f048-4293-9a3b-d6e4215740dd" />


- 10개 이상의 사진을 업로드 하려는 경우
<img width="702" alt="스크린샷 2025-01-25 오후 8 26 51" src="https://github.com/user-attachments/assets/6f9b89f3-40d5-42a6-9d14-b3eff0b28bc2" />



-이미 기록을 업로드 한 날짜로 업로드 시도
<img width="966" alt="스크린샷 2025-01-25 오후 7 28 29" src="https://github.com/user-attachments/assets/fa7fc9ae-f4dc-4b40-b287-baa1b7b481d8" />




## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
