### PR TITLE
[Feat/#85] 기록을 업데이트 하는 API

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/exception/validator/ClothAccessibleValidator.java
+++ b/src/main/java/com/clokey/server/domain/cloth/exception/validator/ClothAccessibleValidator.java
@@ -9,6 +9,8 @@ import com.clokey.server.global.error.code.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class ClothAccessibleValidator {
@@ -37,6 +39,14 @@ public class ClothAccessibleValidator {
         if (isNotMyCloth) {
             throw new ClothException(ErrorStatus.NOT_MY_CLOTH);
         }
+    }
+
+    //다른 입력 인자로 오버로딩
+    public void validateClothOfMember(List<Long> clothIds, Long memberId) {
+
+        clothIds.forEach(clothId -> {
+            validateClothOfMember(clothId,memberId);
+        });
     }
 
     public void validateMemberAccessOfMember(Long memberToBeQueried, Long memberRequestingQuery) {

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -1,7 +1,5 @@
 package com.clokey.server.domain.history.api;
 
-import com.clokey.server.domain.cloth.dto.ClothRequestDTO;
-import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 import com.clokey.server.domain.history.application.HistoryService;
 import com.clokey.server.domain.history.dto.HistoryRequestDTO;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
@@ -11,7 +9,6 @@ import com.clokey.server.domain.history.exception.annotation.HistoryImageQuantit
 import com.clokey.server.domain.history.exception.annotation.MonthFormat;
 import com.clokey.server.domain.history.exception.validator.CommentValidator;
 import com.clokey.server.domain.history.exception.validator.HistoryAccessibleValidator;
-import com.clokey.server.domain.history.exception.validator.HistoryAlreadyExistValidator;
 import com.clokey.server.domain.history.exception.validator.HistoryLikedValidator;
 import com.clokey.server.domain.member.exception.annotation.MemberExist;
 import com.clokey.server.global.common.response.BaseResponse;
@@ -139,11 +136,11 @@ public class HistoryRestController {
 
     //임시로 토큰을 request param으로 받는중.
     @PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "새로운 기록을 생성하는 API", description = "request body에 HistoryCreateRequestDTO 형식의 데이터를 전달해주세요.")
+    @Operation(summary = "새로운 기록을 생성하는 API", description = "request body에 HistoryRequestDTO.HistoryCreate 형식의 데이터를 전달해주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_201", description = "CREATED, 성공적으로 생성되었습니다."),
     })
-    public BaseResponse<HistoryResponseDTO.HistoryCreateResult> postHistory(
+    public BaseResponse<HistoryResponseDTO.HistoryCreateResult> createHistory(
             @RequestPart("historyCreateResult") @Valid HistoryRequestDTO.HistoryCreate historyCreateRequest,
             @RequestPart(value = "imageFile", required = false) @Valid @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
             @RequestParam Long memberId
@@ -153,4 +150,23 @@ public class HistoryRestController {
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_CREATED, result);
     }
+
+    //임시로 토큰을 request param으로 받는중.
+    @PatchMapping(value = "/histories/{historyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "기록을 수정하는 API", description = "request body에 HistoryRequestDTO.HistoryUpdate 형식의 데이터를 전달해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_204", description = "성공적으로 수정되었습니다."),
+    })
+    public BaseResponse<HistoryResponseDTO.HistoryCreateResult> updateHistory(
+            @RequestPart("historyUpdateRequest") @Valid HistoryRequestDTO.HistoryUpdate historyUpdate,
+            @RequestPart(value = "imageFile", required = false) @Valid @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
+            @RequestParam Long memberId
+    ) {
+
+        historyService.updateHistory(historyUpdate, memberId, imageFiles);
+
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_CREATED,null);
+    }
+
+
 }

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -166,7 +166,7 @@ public class HistoryRestController {
 
         historyService.updateHistory(historyUpdate, memberId, historyId, imageFiles);
 
-        return BaseResponse.onSuccess(SuccessStatus.HISTORY_CREATED,null);
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_UPDATED,null);
     }
 
 

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -160,10 +160,11 @@ public class HistoryRestController {
     public BaseResponse<HistoryResponseDTO.HistoryCreateResult> updateHistory(
             @RequestPart("historyUpdateRequest") @Valid HistoryRequestDTO.HistoryUpdate historyUpdate,
             @RequestPart(value = "imageFile", required = false) @Valid @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
-            @RequestParam Long memberId
+            @RequestParam Long memberId,
+            @PathVariable Long historyId
     ) {
 
-        historyService.updateHistory(historyUpdate, memberId, imageFiles);
+        historyService.updateHistory(historyUpdate, memberId, historyId, imageFiles);
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_CREATED,null);
     }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
@@ -1,6 +1,8 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.history.domain.entity.Hashtag;
 import com.clokey.server.domain.history.domain.entity.HashtagHistory;
+import com.clokey.server.domain.history.domain.entity.History;
 
 import java.util.List;
 
@@ -11,4 +13,8 @@ public interface HashtagHistoryRepositoryService {
     List<HashtagHistory> findByHistory_Id(Long historyId);
 
     void save(HashtagHistory hashtagHistory);
+
+    void addHashtagHistory(Hashtag hashtag, History history);
+
+    void deleteHashtagHistory(Hashtag hashtag, History history);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
@@ -1,6 +1,8 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.history.domain.entity.Hashtag;
 import com.clokey.server.domain.history.domain.entity.HashtagHistory;
+import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.repository.HashtagHistoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +31,19 @@ public class HashtagHistoryRepositoryServiceImpl implements HashtagHistoryReposi
     @Override
     public void save(HashtagHistory hashtagHistory) {
         hashtagHistoryRepository.save(hashtagHistory);
+    }
+
+    public void addHashtagHistory(Hashtag hashtag, History history) {
+        // HashtagHistory 엔티티 생성 및 저장
+        HashtagHistory hashtagHistory = HashtagHistory.builder()
+                .hashtag(hashtag)
+                .history(history)
+                .build();
+
+        hashtagHistoryRepository.save(hashtagHistory);
+    }
+
+    public void deleteHashtagHistory(Hashtag hashtag, History history) {
+        hashtagHistoryRepository.deleteByHashtagAndHistory(hashtag, history);
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
@@ -2,10 +2,14 @@ package com.clokey.server.domain.history.application;
 
 import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.history.domain.entity.History;
-import com.clokey.server.domain.history.domain.entity.HistoryCloth;
+
+import java.util.List;
 
 public interface HistoryClothRepositoryService {
 
     void save(History history, Cloth cloth);
 
+    void delete(History history, Cloth cloth);
+
+    List<Long> findClothIdsByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
@@ -1,9 +1,11 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.cloth.domain.entity.Cloth;
+import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.entity.HistoryCloth;
 
 public interface HistoryClothRepositoryService {
 
-    void save(HistoryCloth historyCloth);
+    void save(History history, Cloth cloth);
 
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.cloth.domain.entity.Cloth;
+import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.entity.HistoryCloth;
 import com.clokey.server.domain.history.domain.repository.HistoryClothRepository;
 import jakarta.transaction.Transactional;
@@ -14,7 +16,11 @@ public class HistoryClothRepositoryServiceImpl implements HistoryClothRepository
     private final HistoryClothRepository historyClothRepository;
 
     @Override
-    public void save(HistoryCloth historyCloth) {
-        historyClothRepository.save(historyCloth);
+    public void save(History history , Cloth cloth) {
+        cloth.increaseWearNum();
+        historyClothRepository.save(HistoryCloth.builder()
+                        .history(history)
+                        .cloth(cloth)
+                        .build());
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
@@ -4,9 +4,12 @@ import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.entity.HistoryCloth;
 import com.clokey.server.domain.history.domain.repository.HistoryClothRepository;
+import com.clokey.server.domain.history.domain.repository.HistoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Transactional
 @Service
@@ -14,7 +17,6 @@ import org.springframework.stereotype.Service;
 public class HistoryClothRepositoryServiceImpl implements HistoryClothRepositoryService{
 
     private final HistoryClothRepository historyClothRepository;
-
     @Override
     public void save(History history , Cloth cloth) {
         cloth.increaseWearNum();
@@ -22,5 +24,16 @@ public class HistoryClothRepositoryServiceImpl implements HistoryClothRepository
                         .history(history)
                         .cloth(cloth)
                         .build());
+    }
+
+    @Override
+    public void delete(History history, Cloth cloth) {
+        cloth.decreaseWearNum();
+        historyClothRepository.deleteByHistoryAndCloth(history,cloth);
+    }
+
+    @Override
+    public List<Long> findClothIdsByHistoryId(Long historyId){
+        return historyClothRepository.findClothIdsByHistoryId(historyId);
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
@@ -16,5 +16,5 @@ public interface HistoryImageRepositoryService {
 
     void save(List<MultipartFile> historyImages , History history);
 
-    void deleteAllByHistory_Id(Long historyId);
+    void deleteAllByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
@@ -12,4 +12,5 @@ public interface HistoryImageRepositoryService {
 
     HistoryImage save(HistoryImage historyImage);
 
+    void deleteAllByHistory_Id(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryService.java
@@ -1,6 +1,8 @@
 package com.clokey.server.domain.history.application;
 
+import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.entity.HistoryImage;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -10,7 +12,9 @@ public interface HistoryImageRepositoryService {
 
     List<HistoryImage> findByHistory_Id(Long historyId);
 
-    HistoryImage save(HistoryImage historyImage);
+    void save(MultipartFile historyImage, History history);
+
+    void save(List<MultipartFile> historyImages , History history);
 
     void deleteAllByHistory_Id(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
@@ -60,6 +60,10 @@ public class HistoryImageRepositoryServiceImpl implements HistoryImageRepository
         // 특정 historyId에 해당하는 모든 이미지를 조회
         List<HistoryImage> historyImages = historyImageRepository.findByHistory_Id(historyId);
 
+        if(historyImages.isEmpty()) {
+            return;
+        }
+
         // S3 및 데이터베이스에서 이미지 삭제
         historyImages.forEach(image -> {
             // S3에서 이미지 삭제

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
@@ -60,7 +60,7 @@ public class HistoryImageRepositoryServiceImpl implements HistoryImageRepository
         // 특정 historyId에 해당하는 모든 이미지를 조회
         List<HistoryImage> historyImages = historyImageRepository.findByHistory_Id(historyId);
 
-        if(historyImages.isEmpty()) {
+        if(historyImages == null || historyImages.isEmpty()) {
             return;
         }
 

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryImageRepositoryServiceImpl.java
@@ -56,7 +56,7 @@ public class HistoryImageRepositoryServiceImpl implements HistoryImageRepository
     }
 
 
-    public void deleteAllByHistory_Id(Long historyId) {
+    public void deleteAllByHistoryId(Long historyId) {
         // 특정 historyId에 해당하는 모든 이미지를 조회
         List<HistoryImage> historyImages = historyImageRepository.findByHistory_Id(historyId);
 

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
@@ -20,4 +20,5 @@ public interface HistoryService {
 
     HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest, Long memberId, List<MultipartFile> images);
 
+    void updateHistory(HistoryRequestDTO.HistoryUpdate historyUpdate, Long memberId, Long historyId, List<MultipartFile> images);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -5,6 +5,7 @@ import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.cloth.exception.validator.ClothAccessibleValidator;
 import com.clokey.server.domain.history.domain.entity.*;
 import com.clokey.server.domain.history.dto.HistoryRequestDTO;
+import com.clokey.server.domain.history.exception.validator.HistoryAccessibleValidator;
 import com.clokey.server.domain.history.exception.validator.HistoryAlreadyExistValidator;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.domain.entity.Member;
@@ -33,11 +34,11 @@ public class HistoryServiceImpl implements HistoryService{
     private final MemberLikeRepositoryService memberLikeRepositoryService;
     private final HistoryImageRepositoryService historyImageRepositoryService;
     private final HashtagHistoryRepositoryService hashtagHistoryRepositoryService;
-    private final S3ImageService s3ImageService;
     private final ClothRepositoryService clothRepositoryService;
     private final HashtagRepositoryService hashtagRepositoryService;
     private final ClothAccessibleValidator clothAccessibleValidator;
     private final HistoryClothRepositoryService historyClothRepositoryService;
+    private final HistoryAccessibleValidator historyAccessibleValidator;
 
     @Override
     public HistoryResponseDTO.LikeResult changeLike(Long memberId, Long historyId, boolean isLiked) {
@@ -191,6 +192,12 @@ public class HistoryServiceImpl implements HistoryService{
     @Override
     @Transactional
     public void updateHistory(HistoryRequestDTO.HistoryUpdate historyUpdate, Long memberId, Long historyId, List<MultipartFile> images) {
+
+        //나의 기록이 맞는지 검증합니다.
+        historyAccessibleValidator.validateMyHistory(historyId,memberId);
+
+        //모든 옷이 나의 옷이 맞는지 검증합니다.
+        clothAccessibleValidator.validateClothOfMember(historyUpdate.getClothes(),memberId);
 
         historyImageRepositoryService.deleteAllByHistory_Id(historyId);
         historyImageRepositoryService.save(images,historyRepositoryService.findById(historyId));

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -152,7 +152,7 @@ public class HistoryServiceImpl implements HistoryService{
         }
 
 
-        //모든 옷의 착용횟수를 1올리고 기록-옷 테이블에 추가해줍니다.
+        //기록-옷 테이블에 추가해줍니다.
         historyCreateRequest.getClothes()
                 .forEach(clothId-> {
                     historyClothRepositoryService.save(history,clothRepositoryService.findById(clothId));
@@ -230,7 +230,18 @@ public class HistoryServiceImpl implements HistoryService{
 
     private void updateHistoryHashtags(List<String> updatedHashtags, List<String> savedHashtags, History history){
 
-        //updateHashtag에만 존재하는 것은 추가 대상
+        //존재하지 않는 해시태그는 만들어줍니다.
+        updatedHashtags.forEach(hashtagName->{
+            if(!hashtagRepositoryService.existByName(hashtagName)) {
+                Hashtag newHashtag = Hashtag.builder()
+                        .name(hashtagName)
+                        .build();
+                hashtagRepositoryService.save(newHashtag);
+            }
+        });
+
+
+        //updateHashtag에만 존재하는 것은 매핑 테이블에
         List<Hashtag> hashtagToAdd = updatedHashtags.stream()
                 .filter(hashtagNames -> !savedHashtags.contains(hashtagNames))
                 .map(hashtagRepositoryService::findByName)

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -11,7 +11,6 @@ import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.history.converter.HistoryConverter;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
-import com.clokey.server.global.infra.s3.S3ImageService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -199,7 +198,7 @@ public class HistoryServiceImpl implements HistoryService{
         //모든 옷이 나의 옷이 맞는지 검증합니다.
         clothAccessibleValidator.validateClothOfMember(historyUpdate.getClothes(),memberId);
 
-        historyImageRepositoryService.deleteAllByHistory_Id(historyId);
+        historyImageRepositoryService.deleteAllByHistoryId(historyId);
         if(images != null && !images.isEmpty()){
             historyImageRepositoryService.save(images,historyRepositoryService.findById(historyId));
         }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -199,6 +199,14 @@ public class HistoryServiceImpl implements HistoryService{
                 historyClothRepositoryService.findClothIdsByHistoryId(historyId),
                 historyRepositoryService.findById(historyId));
 
+        updateHistoryHashtags(
+                historyUpdate.getHashtags(),
+                hashtagHistoryRepositoryService.findByHistory_Id(historyId).stream()
+                        .map(hashtagHistory -> hashtagHistory.getHashtag().getName())
+                        .toList(),
+                historyRepositoryService.findById(historyId));
+
+
 
     }
 
@@ -218,6 +226,24 @@ public class HistoryServiceImpl implements HistoryService{
 
         clothesToAdd.forEach(cloth->historyClothRepositoryService.save(history,cloth));
         clothesToDelete.forEach(cloth->historyClothRepositoryService.delete(history,cloth));
+    }
+
+    private void updateHistoryHashtags(List<String> updatedHashtags, List<String> savedHashtags, History history){
+
+        //updateHashtag에만 존재하는 것은 추가 대상
+        List<Hashtag> hashtagToAdd = updatedHashtags.stream()
+                .filter(hashtagNames -> !savedHashtags.contains(hashtagNames))
+                .map(hashtagRepositoryService::findByName)
+                .toList();
+
+        //반대는 삭제 대상
+        List<Hashtag> hashtagToDelete = savedHashtags.stream()
+                .filter(hashtagNames -> !updatedHashtags.contains(hashtagNames))
+                .map(hashtagRepositoryService::findByName)
+                .toList();
+
+        hashtagToAdd.forEach(hashtag -> hashtagHistoryRepositoryService.addHashtagHistory(hashtag,history));
+        hashtagToDelete.forEach(hashtag -> hashtagHistoryRepositoryService.deleteHashtagHistory(hashtag,history));
     }
 
 

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -189,6 +189,7 @@ public class HistoryServiceImpl implements HistoryService{
     }
 
     @Override
+    @Transactional
     public void updateHistory(HistoryRequestDTO.HistoryUpdate historyUpdate, Long memberId, Long historyId, List<MultipartFile> images) {
 
         historyImageRepositoryService.deleteAllByHistory_Id(historyId);
@@ -206,8 +207,8 @@ public class HistoryServiceImpl implements HistoryService{
                         .toList(),
                 historyRepositoryService.findById(historyId));
 
-
-
+        History historyToUpdate = historyRepositoryService.findById(historyId);
+        historyToUpdate.updateHistory(historyUpdate.getContent(),historyUpdate.getVisibility());
     }
 
     private void updateHistoryClothes(List<Long> updatedClothes, List<Long> savedClothes, History history) {

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -200,7 +200,9 @@ public class HistoryServiceImpl implements HistoryService{
         clothAccessibleValidator.validateClothOfMember(historyUpdate.getClothes(),memberId);
 
         historyImageRepositoryService.deleteAllByHistory_Id(historyId);
-        historyImageRepositoryService.save(images,historyRepositoryService.findById(historyId));
+        if(images != null && !images.isEmpty()){
+            historyImageRepositoryService.save(images,historyRepositoryService.findById(historyId));
+        }
 
         updateHistoryClothes(
                 historyUpdate.getClothes(),

--- a/src/main/java/com/clokey/server/domain/history/domain/entity/History.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/entity/History.java
@@ -37,4 +37,13 @@ public class History extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public void updateHistory(String content, Visibility visibility){
+        if (content != null){
+            this.content = content;
+        }
+        if (visibility != null){
+            this.visibility = visibility;
+        }
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagHistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagHistoryRepository.java
@@ -1,7 +1,13 @@
 package com.clokey.server.domain.history.domain.repository;
 
+import com.clokey.server.domain.history.domain.entity.Hashtag;
 import com.clokey.server.domain.history.domain.entity.HashtagHistory;
+import com.clokey.server.domain.history.domain.entity.History;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +17,8 @@ public interface HashtagHistoryRepository extends JpaRepository<HashtagHistory, 
 
     List<HashtagHistory> findByHistory_Id(Long historyId);
 
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM HashtagHistory hh WHERE hh.hashtag = :hashtag AND hh.history = :history")
+    void deleteByHashtagAndHistory(@Param("hashtag") Hashtag hashtag, @Param("history") History history);
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryClothRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryClothRepository.java
@@ -1,14 +1,28 @@
 package com.clokey.server.domain.history.domain.repository;
 
+import com.clokey.server.domain.cloth.domain.entity.Cloth;
+import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.entity.HistoryCloth;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface HistoryClothRepository extends JpaRepository<HistoryCloth, Long> {
 
     @Transactional
     @Modifying
     void deleteAllByClothId(@Param("clothId") Long clothId);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM HistoryCloth hc WHERE hc.history = :history AND hc.cloth = :cloth")
+    void deleteByHistoryAndCloth(@Param("history") History history, @Param("cloth") Cloth cloth);
+
+
+    @Query("SELECT hc.cloth.id FROM HistoryCloth hc WHERE hc.history.id = :historyId")
+    List<Long> findClothIdsByHistoryId(@Param("historyId") Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -1,11 +1,9 @@
 package com.clokey.server.domain.history.domain.repository;
 
 import com.clokey.server.domain.history.domain.entity.History;
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -34,6 +34,21 @@ public class HistoryRequestDTO {
         String date;
     }
 
+    public static class HistoryUpdate {
+
+        @HistoryContentLength
+        String content;
+
+        @UniqueClothes
+        List<Long> clothes;
+
+        @UniqueHashtags
+        List<String> hashtags;
+
+        Visibility visibility;
+
+    }
+
 
     @Builder
     @Getter

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -34,6 +34,10 @@ public class HistoryRequestDTO {
         String date;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class HistoryUpdate {
 
         @HistoryContentLength

--- a/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryAccessibleValidator.java
+++ b/src/main/java/com/clokey/server/domain/history/exception/validator/HistoryAccessibleValidator.java
@@ -2,6 +2,7 @@ package com.clokey.server.domain.history.exception.validator;
 
 import com.clokey.server.domain.history.application.HistoryRepositoryService;
 import com.clokey.server.domain.history.domain.entity.History;
+import com.clokey.server.domain.history.exception.HistoryException;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.model.entity.enums.Visibility;
 import com.clokey.server.domain.history.domain.repository.HistoryRepository;
@@ -28,7 +29,7 @@ public class HistoryAccessibleValidator {
         boolean isNotMyHistory = !history.getMember().getId().equals(memberId);
 
         if (isPrivate && isNotMyHistory) {
-            throw new GeneralException(ErrorStatus.NO_PERMISSION_TO_ACCESS_HISTORY);
+            throw new HistoryException(ErrorStatus.NO_PERMISSION_TO_ACCESS_HISTORY);
         }
     }
 
@@ -41,9 +42,21 @@ public class HistoryAccessibleValidator {
                 .equals(Visibility.PRIVATE);
 
         if(!selfQuery && isPrivate) {
-            throw new GeneralException(ErrorStatus.NO_PERMISSION_TO_ACCESS_HISTORY);
+            throw new HistoryException(ErrorStatus.NO_PERMISSION_TO_ACCESS_HISTORY);
         }
 
+    }
+
+    public void validateMyHistory(Long historyId, Long MemberId){
+
+        boolean isValid = historyRepositoryService.findById(historyId)
+                .getMember()
+                .getId()
+                .equals(MemberId);
+
+        if(!isValid) {
+            throw new HistoryException(ErrorStatus.NOT_MY_HISTORY);
+        }
     }
 
 }

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -59,6 +59,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_CLOTHES_FOR_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4011","기록에 중복된 옷을 등록할 수 없습니다"),
     HISTORY_ALREADY_EXIST_FOR_DATE(HttpStatus.BAD_REQUEST,"HISTORY_4012","이미 기록이 존재하는 날짜입니다."),
     IMAGE_QUANTITY_OVER_HISTORY_IMAGE_LIMIT(HttpStatus.BAD_REQUEST,"HISTORY_4013","사진을 10개 넘게 업로드 할 수 없습니다."),
+    NOT_MY_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4014","나의 기록이 아닙니다"),
 
     //해시태그 에러
     NO_SUCH_HASHTAG_NAME(HttpStatus.BAD_REQUEST,"HASHTAG_4001","해당 이름의 해시태그가 존재하지 않습니다"),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -59,7 +59,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_CLOTHES_FOR_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4011","기록에 중복된 옷을 등록할 수 없습니다"),
     HISTORY_ALREADY_EXIST_FOR_DATE(HttpStatus.BAD_REQUEST,"HISTORY_4012","이미 기록이 존재하는 날짜입니다."),
     IMAGE_QUANTITY_OVER_HISTORY_IMAGE_LIMIT(HttpStatus.BAD_REQUEST,"HISTORY_4013","사진을 10개 넘게 업로드 할 수 없습니다."),
-    NOT_MY_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4014","나의 기록이 아닙니다"),
+    NOT_MY_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4014","사용자의 기록이 아닙니다"),
 
     //해시태그 에러
     NO_SUCH_HASHTAG_NAME(HttpStatus.BAD_REQUEST,"HASHTAG_4001","해당 이름의 해시태그가 존재하지 않습니다"),

--- a/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
@@ -39,6 +39,7 @@ public enum SuccessStatus implements BaseCode {
     HISTORY_CREATED(HttpStatus.CREATED, "HISTORY_201", "성공적으로 생성되었습니다."),
     HISTORY_LIKE_STATUS_CHANGED(HttpStatus.OK,"HISTORY_200","좋아요 상태가 성공적으로 변경되었습니다."),
     HISTORY_COMMENT_CREATED(HttpStatus.CREATED,"HISTORY_201","성공적으로 댓글이 생성되었습니다."),
+    HISTORY_UPDATED(HttpStatus.NO_CONTENT,"HISTORY_204","성공적으로 수정되었습니다"),
 
     //알림 성공
     NOTIFICATION_SUCCESS(HttpStatus.OK, "NOTIFICATION_200", "성공적으로 조회되었습니다."),


### PR DESCRIPTION
## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #85 

## 🌱 PR 요약
- 기록을 업데이트 하는 API입니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->

### 기능

- 해당 날짜의 옷 기록을 수정하는 API입니다

- 임시로 MemberId는 Path_variable로 받습니다. 

- 등록된 옷이 삭제되거나 추가될 경우 그에 맞게 WearNum이 업데이트 됩니다.

- 해시태그를 삭제한다고 해서 해시태그의 존재가 사라지진 않습니다. 다만 새로운 해시태그는 반영됩니다.

- 사진이 수정됩니다. 사진은 전체 사진을 삭제하고 다시 업로드 합니다. 

- 사진과 관련된 기능은 비효율적이라면 리펙토링 대상입니다. (다른 방법을 어캐 구현할지 몰라서 일단 했습니다.)

### 에러

- 나의 기록이 맞는지 ✅

- 옷이 나의 옷장에 있는 옷이 맞는지. ✅

- 같은 옷이 두번 clothes List가 unique하지 않다.  ✅

- content가 200자를 넘어가는 경우  ✅

- 중복된 해시태그 hashtag List가 unique 하지 않다. ✅

- 사진이 10개이상 ✅

## 📸 스크린샷
- 성공
<img width="969" alt="스크린샷 2025-01-26 오후 6 02 55" src="https://github.com/user-attachments/assets/08bac493-a5c9-4c71-9c1f-f10ef0b80cfe" />

-실패(나의 기록이 아닌 경우)
<img width="969" alt="스크린샷 2025-01-26 오후 6 10 16" src="https://github.com/user-attachments/assets/da3bc841-f0fe-4839-a00e-07dba2e35570" />

-실패(나의 옷장의 옷이 아닌 경우)
<img width="969" alt="스크린샷 2025-01-26 오후 6 11 19" src="https://github.com/user-attachments/assets/034b9149-bd94-4aee-9790-04ad9ffe7cce" />

-실패 (같은 옷을 중복해서 등록하는 경우)
<img width="969" alt="스크린샷 2025-01-26 오후 6 14 36" src="https://github.com/user-attachments/assets/6bda93c3-f845-4f7b-928d-66e215dddab0" />

-실패(Content가 200자를 넘어가는 경우)
<img width="969" alt="스크린샷 2025-01-26 오후 6 17 34" src="https://github.com/user-attachments/assets/7553e3b1-6756-4371-82d3-b30e3a9f948a" />


-실패(중복된 해시태그 hashta List가 unique 하지 않다)
<img width="969" alt="스크린샷 2025-01-26 오후 6 18 08" src="https://github.com/user-attachments/assets/26e5dbab-7579-409a-97ca-66f61a7be5ed" />


-실패(사진이 10개 이상)
<img width="969" alt="스크린샷 2025-01-26 오후 6 20 15" src="https://github.com/user-attachments/assets/f5f5be43-5124-474d-9560-399c2dfd34d3" />


## ❗️리뷰어들께
- Transaction 등의 리펙토링 사항은 전부 구현 후 한번에 분리하겠습니다!
