### PR TITLE
[Feat/#88] 댓글 수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -141,7 +141,7 @@ public class HistoryRestController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_201", description = "CREATED, 성공적으로 생성되었습니다."),
     })
     public BaseResponse<HistoryResponseDTO.HistoryCreateResult> createHistory(
-            @RequestPart("historyCreateResult") @Valid HistoryRequestDTO.HistoryCreate historyCreateRequest,
+            @RequestPart("historyCreateRequest") @Valid HistoryRequestDTO.HistoryCreate historyCreateRequest,
             @RequestPart(value = "imageFile", required = false) @Valid @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
             @RequestParam Long memberId
     ) {
@@ -171,7 +171,7 @@ public class HistoryRestController {
 
     //임시로 토큰을 request param으로 받는중.
     @DeleteMapping(value = "/comments/{commentId}")
-    @Operation(summary = "댓글을 삭제하는 API", description = "Path Parameter로 history Id와 Comment Id를 입력해주세요.")
+    @Operation(summary = "댓글을 삭제하는 API", description = "Path Parameter로 Comment Id를 입력해주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_204", description = "댓글이 성공적으로 삭제되었습니다."),
     })
@@ -184,6 +184,24 @@ public class HistoryRestController {
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_COMMENT_DELETED,null);
     }
+
+    //임시로 토큰을 request param으로 받는중.
+    @PatchMapping(value = "/comments/{commentId}")
+    @Operation(summary = "댓글을 수정하는 API", description = "Path Parameter로 Comment Id를 입력해주세요, HistoryRequestDTO.UpdateComment에는 수정되는 내용을 담아주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_204", description = "댓글이 성공적으로 수정되었습니다."),
+    })
+    public BaseResponse<Void> updateComment(
+            @RequestPart("UpdateCommentRequest") @Valid HistoryRequestDTO.UpdateComment updateCommentRequest,
+            @RequestParam Long memberId,
+            @PathVariable Long commentId
+    ) {
+
+        historyService.updateComment(updateCommentRequest,commentId,memberId);
+
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_COMMENT_UPDATED,null);
+    }
+
 
 
 

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -152,12 +152,12 @@ public class HistoryRestController {
     }
 
     //임시로 토큰을 request param으로 받는중.
-    @PatchMapping(value = "/histories/{historyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(value = "/{historyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "기록을 수정하는 API", description = "request body에 HistoryRequestDTO.HistoryUpdate 형식의 데이터를 전달해주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_204", description = "성공적으로 수정되었습니다."),
     })
-    public BaseResponse<HistoryResponseDTO.HistoryCreateResult> updateHistory(
+    public BaseResponse<Void> updateHistory(
             @RequestPart("historyUpdateRequest") @Valid HistoryRequestDTO.HistoryUpdate historyUpdate,
             @RequestPart(value = "imageFile", required = false) @Valid @HistoryImageQuantityLimit List<MultipartFile> imageFiles,
             @RequestParam Long memberId,
@@ -168,6 +168,24 @@ public class HistoryRestController {
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_UPDATED,null);
     }
+
+    //임시로 토큰을 request param으로 받는중.
+    @DeleteMapping(value = "/comments/{commentId}")
+    @Operation(summary = "댓글을 삭제하는 API", description = "Path Parameter로 history Id와 Comment Id를 입력해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_204", description = "댓글이 성공적으로 삭제되었습니다."),
+    })
+    public BaseResponse<Void> deleteComment(
+            @RequestParam Long memberId,
+            @PathVariable Long commentId
+    ) {
+
+        historyService.deleteComment(commentId,memberId);
+
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_COMMENT_DELETED,null);
+    }
+
+
 
 
 }

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -192,7 +192,7 @@ public class HistoryRestController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_204", description = "댓글이 성공적으로 수정되었습니다."),
     })
     public BaseResponse<Void> updateComment(
-            @RequestPart("UpdateCommentRequest") @Valid HistoryRequestDTO.UpdateComment updateCommentRequest,
+            @RequestBody @Valid HistoryRequestDTO.UpdateComment updateCommentRequest,
             @RequestParam Long memberId,
             @PathVariable Long commentId
     ) {

--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
@@ -17,4 +17,6 @@ public interface CommentRepositoryService {
     Comment save(Comment comment);
 
     boolean existsById(Long commentId);
+
+    void deleteWithChildren(Long commentId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
@@ -18,5 +18,7 @@ public interface CommentRepositoryService {
 
     boolean existsById(Long commentId);
 
-    void deleteWithChildren(Long commentId);
+    void deleteChildren(Long commentId);
+
+    void deleteById(Long commentId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
@@ -45,4 +45,9 @@ public class CommentRepositoryServiceImpl implements CommentRepositoryService{
         return commentRepository.existsById(commentId);
     }
 
+    @Override
+    public void deleteWithChildren(Long commentId) {
+        commentRepository.deleteWithChildren(commentId);
+    }
+
 }

--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
@@ -46,8 +46,13 @@ public class CommentRepositoryServiceImpl implements CommentRepositoryService{
     }
 
     @Override
-    public void deleteWithChildren(Long commentId) {
-        commentRepository.deleteWithChildren(commentId);
+    public void deleteChildren(Long commentId) {
+        commentRepository.deleteChildren(commentId);
+    }
+
+    @Override
+    public void deleteById(Long commentId) {
+        commentRepository.deleteById(commentId);
     }
 
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
@@ -21,4 +21,6 @@ public interface HistoryService {
     HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest, Long memberId, List<MultipartFile> images);
 
     void updateHistory(HistoryRequestDTO.HistoryUpdate historyUpdate, Long memberId, Long historyId, List<MultipartFile> images);
+
+    void deleteComment(Long commentId,Long memberId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
@@ -23,4 +23,6 @@ public interface HistoryService {
     void updateHistory(HistoryRequestDTO.HistoryUpdate historyUpdate, Long memberId, Long historyId, List<MultipartFile> images);
 
     void deleteComment(Long commentId,Long memberId);
+
+    void updateComment(HistoryRequestDTO.UpdateComment updateCommentRequest,Long commentId,Long memberId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -5,12 +5,14 @@ import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.cloth.exception.validator.ClothAccessibleValidator;
 import com.clokey.server.domain.history.domain.entity.*;
 import com.clokey.server.domain.history.dto.HistoryRequestDTO;
+import com.clokey.server.domain.history.exception.HistoryException;
 import com.clokey.server.domain.history.exception.validator.HistoryAccessibleValidator;
 import com.clokey.server.domain.history.exception.validator.HistoryAlreadyExistValidator;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.history.converter.HistoryConverter;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
+import com.clokey.server.global.error.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,7 +26,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class HistoryServiceImpl implements HistoryService{
+public class HistoryServiceImpl implements HistoryService {
 
     private final HistoryAlreadyExistValidator historyAlreadyExistValidator;
     private final HistoryRepositoryService historyRepositoryService;
@@ -44,9 +46,9 @@ public class HistoryServiceImpl implements HistoryService{
 
         History history = historyRepositoryService.findById(historyId);
 
-        if(isLiked) {
+        if (isLiked) {
             historyRepositoryService.decrementLikes(historyId);
-            memberLikeRepositoryService.deleteByMember_IdAndHistory_Id(memberId,historyId);
+            memberLikeRepositoryService.deleteByMember_IdAndHistory_Id(memberId, historyId);
         } else {
             historyRepositoryService.incrementLikes(historyId);
             MemberLike memberLike = MemberLike.builder()
@@ -84,7 +86,7 @@ public class HistoryServiceImpl implements HistoryService{
     }
 
     @Override
-    public HistoryResponseDTO.DayViewResult getDaily(Long historyId, Long memberId){
+    public HistoryResponseDTO.DayViewResult getDaily(Long historyId, Long memberId) {
         History history = historyRepositoryService.findById(historyId);
         List<HistoryImage> historyImages = historyImageRepositoryService.findByHistory_Id(historyId);
         List<String> imageUrl = historyImages.stream()
@@ -96,22 +98,22 @@ public class HistoryServiceImpl implements HistoryService{
                 .map(Hashtag::getName)
                 .toList();
         int likeCount = memberLikeRepositoryService.countByHistory_Id(historyId);
-        boolean isLiked = memberLikeRepositoryService.existsByMember_IdAndHistory_Id(memberId,historyId);
+        boolean isLiked = memberLikeRepositoryService.existsByMember_IdAndHistory_Id(memberId, historyId);
 
         return HistoryConverter.toDayViewResult(history, imageUrl, hashtags, likeCount, isLiked);
     }
 
     @Override
     public HistoryResponseDTO.HistoryCommentResult getComments(Long historyId, int page) {
-        Page<Comment> comments = commentRepositoryService.findByHistoryIdAndCommentIsNull(historyId, PageRequest.of(page,10, Sort.by(Sort.Direction.ASC, "createdAt")));
+        Page<Comment> comments = commentRepositoryService.findByHistoryIdAndCommentIsNull(historyId, PageRequest.of(page, 10, Sort.by(Sort.Direction.ASC, "createdAt")));
         List<List<Comment>> repliesForEachComment = comments.stream()
                 .map(comment -> commentRepositoryService.findByCommentId(comment.getId()))
                 .toList();
-        return  HistoryConverter.toHistoryCommentResult(comments, repliesForEachComment);
+        return HistoryConverter.toHistoryCommentResult(comments, repliesForEachComment);
     }
 
     @Override
-    public HistoryResponseDTO.MonthViewResult getMonthlyHistories(Long this_member_id, Long memberId, String month){
+    public HistoryResponseDTO.MonthViewResult getMonthlyHistories(Long this_member_id, Long memberId, String month) {
         List<History> histories = historyRepositoryService.findHistoriesByMemberAndYearMonth(memberId, month);
         List<String> historyImageUrls = histories.stream()
                 .map(history -> historyImageRepositoryService.findByHistory_Id(history.getId())
@@ -135,41 +137,39 @@ public class HistoryServiceImpl implements HistoryService{
 
     @Override
     @Transactional
-    public HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest,Long memberId, List<MultipartFile> imageFiles) {
+    public HistoryResponseDTO.HistoryCreateResult createHistory(HistoryRequestDTO.HistoryCreate historyCreateRequest, Long memberId, List<MultipartFile> imageFiles) {
 
         //이미 해당 날짜에 기록이 존재하는지 검증합니다.
-        historyAlreadyExistValidator.validate(memberId,historyCreateRequest.getDate());
+        historyAlreadyExistValidator.validate(memberId, historyCreateRequest.getDate());
 
         //모든 옷이 나의 옷이 맞는지 검증합니다.
-        clothAccessibleValidator.validateClothOfMember(historyCreateRequest.getClothes(),memberId);
+        clothAccessibleValidator.validateClothOfMember(historyCreateRequest.getClothes(), memberId);
 
         // History 엔티티 생성 후 요청 정보 반환해서 저장
         History history = historyRepositoryService.save(HistoryConverter.toHistory(historyCreateRequest, memberRepositoryService.findMemberById(memberId)));
 
         // 이미지는 첨부했다면 업로드를 진행합니다.
-        if (imageFiles != null && !imageFiles.isEmpty()){
-           historyImageRepositoryService.save(imageFiles,history);
+        if (imageFiles != null && !imageFiles.isEmpty()) {
+            historyImageRepositoryService.save(imageFiles, history);
         }
 
 
         //기록-옷 테이블에 추가해줍니다.
         historyCreateRequest.getClothes()
-                .forEach(clothId-> {
-                    historyClothRepositoryService.save(history,clothRepositoryService.findById(clothId));
+                .forEach(clothId -> {
+                    historyClothRepositoryService.save(history, clothRepositoryService.findById(clothId));
                 });
-
-
 
 
         historyCreateRequest.getHashtags()
                 .forEach(hashtagNames -> {
                     //존재하는 해시태그라면 매핑 테이블에 추가
                     //아니라면 새로운 해시태그를 만들고 매핑 테이블에 추가
-                    if(hashtagRepositoryService.existByName(hashtagNames)){
+                    if (hashtagRepositoryService.existByName(hashtagNames)) {
                         hashtagHistoryRepositoryService.save(HashtagHistory.builder()
-                                        .history(history)
-                                        .hashtag(hashtagRepositoryService.findByName(hashtagNames))
-                                        .build()
+                                .history(history)
+                                .hashtag(hashtagRepositoryService.findByName(hashtagNames))
+                                .build()
                         );
                     } else {
                         Hashtag newHashtag = Hashtag.builder()
@@ -178,9 +178,9 @@ public class HistoryServiceImpl implements HistoryService{
                         hashtagRepositoryService.save(newHashtag);
 
                         hashtagHistoryRepositoryService.save(HashtagHistory.builder()
-                                        .history(history)
-                                        .hashtag(newHashtag)
-                                        .build()
+                                .history(history)
+                                .hashtag(newHashtag)
+                                .build()
                         );
                     }
                 });
@@ -193,14 +193,14 @@ public class HistoryServiceImpl implements HistoryService{
     public void updateHistory(HistoryRequestDTO.HistoryUpdate historyUpdate, Long memberId, Long historyId, List<MultipartFile> images) {
 
         //나의 기록이 맞는지 검증합니다.
-        historyAccessibleValidator.validateMyHistory(historyId,memberId);
+        historyAccessibleValidator.validateMyHistory(historyId, memberId);
 
         //모든 옷이 나의 옷이 맞는지 검증합니다.
-        clothAccessibleValidator.validateClothOfMember(historyUpdate.getClothes(),memberId);
+        clothAccessibleValidator.validateClothOfMember(historyUpdate.getClothes(), memberId);
 
         historyImageRepositoryService.deleteAllByHistoryId(historyId);
-        if(images != null && !images.isEmpty()){
-            historyImageRepositoryService.save(images,historyRepositoryService.findById(historyId));
+        if (images != null && !images.isEmpty()) {
+            historyImageRepositoryService.save(images, historyRepositoryService.findById(historyId));
         }
 
         updateHistoryClothes(
@@ -216,7 +216,20 @@ public class HistoryServiceImpl implements HistoryService{
                 historyRepositoryService.findById(historyId));
 
         History historyToUpdate = historyRepositoryService.findById(historyId);
-        historyToUpdate.updateHistory(historyUpdate.getContent(),historyUpdate.getVisibility());
+        historyToUpdate.updateHistory(historyUpdate.getContent(), historyUpdate.getVisibility());
+    }
+
+    @Override
+    public void deleteComment(Long commentId, Long memberId) {
+        validateMyComment(commentId,memberId);
+        commentRepositoryService.deleteWithChildren(commentId);
+    }
+
+    private void validateMyComment(Long commentId, Long memberId) {
+        Comment comment = commentRepositoryService.findById(commentId);
+        if(!comment.getMember().getId().equals(memberId)){
+            throw new HistoryException(ErrorStatus.NOT_MY_COMMENT);
+        }
     }
 
     private void updateHistoryClothes(List<Long> updatedClothes, List<Long> savedClothes, History history) {
@@ -233,15 +246,15 @@ public class HistoryServiceImpl implements HistoryService{
                 .map(clothRepositoryService::findById)
                 .toList();
 
-        clothesToAdd.forEach(cloth->historyClothRepositoryService.save(history,cloth));
-        clothesToDelete.forEach(cloth->historyClothRepositoryService.delete(history,cloth));
+        clothesToAdd.forEach(cloth -> historyClothRepositoryService.save(history, cloth));
+        clothesToDelete.forEach(cloth -> historyClothRepositoryService.delete(history, cloth));
     }
 
-    private void updateHistoryHashtags(List<String> updatedHashtags, List<String> savedHashtags, History history){
+    private void updateHistoryHashtags(List<String> updatedHashtags, List<String> savedHashtags, History history) {
 
         //존재하지 않는 해시태그는 만들어줍니다.
-        updatedHashtags.forEach(hashtagName->{
-            if(!hashtagRepositoryService.existByName(hashtagName)) {
+        updatedHashtags.forEach(hashtagName -> {
+            if (!hashtagRepositoryService.existByName(hashtagName)) {
                 Hashtag newHashtag = Hashtag.builder()
                         .name(hashtagName)
                         .build();
@@ -262,8 +275,8 @@ public class HistoryServiceImpl implements HistoryService{
                 .map(hashtagRepositoryService::findByName)
                 .toList();
 
-        hashtagToAdd.forEach(hashtag -> hashtagHistoryRepositoryService.addHashtagHistory(hashtag,history));
-        hashtagToDelete.forEach(hashtag -> hashtagHistoryRepositoryService.deleteHashtagHistory(hashtag,history));
+        hashtagToAdd.forEach(hashtag -> hashtagHistoryRepositoryService.addHashtagHistory(hashtag, history));
+        hashtagToDelete.forEach(hashtag -> hashtagHistoryRepositoryService.deleteHashtagHistory(hashtag, history));
     }
 
 

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -222,7 +222,8 @@ public class HistoryServiceImpl implements HistoryService {
     @Override
     public void deleteComment(Long commentId, Long memberId) {
         validateMyComment(commentId,memberId);
-        commentRepositoryService.deleteWithChildren(commentId);
+        commentRepositoryService.deleteChildren(commentId);
+        commentRepositoryService.deleteById(commentId);
     }
 
     private void validateMyComment(Long commentId, Long memberId) {

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -220,10 +220,19 @@ public class HistoryServiceImpl implements HistoryService {
     }
 
     @Override
+    @Transactional
     public void deleteComment(Long commentId, Long memberId) {
         validateMyComment(commentId,memberId);
         commentRepositoryService.deleteChildren(commentId);
         commentRepositoryService.deleteById(commentId);
+    }
+
+    @Override
+    @Transactional
+    public void updateComment(HistoryRequestDTO.UpdateComment updateCommentRequest,Long commentId, Long memberId) {
+        validateMyComment(commentId,memberId);
+        Comment commentToUpdate = commentRepositoryService.findById(commentId);
+        commentToUpdate.updateContent(updateCommentRequest.getContent());
     }
 
     private void validateMyComment(Long commentId, Long memberId) {

--- a/src/main/java/com/clokey/server/domain/history/domain/entity/Comment.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/entity/Comment.java
@@ -30,5 +30,11 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment comment;
+
+    public void updateContent(String content) {
+        if(content != null && content.isEmpty()) {
+            this.content = content;
+        }
+    }
 }
 

--- a/src/main/java/com/clokey/server/domain/history/domain/entity/Comment.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/entity/Comment.java
@@ -32,7 +32,7 @@ public class Comment extends BaseEntity {
     private Comment comment;
 
     public void updateContent(String content) {
-        if(content != null && content.isEmpty()) {
+        if(content != null && !content.isEmpty()) {
             this.content = content;
         }
     }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
@@ -19,6 +19,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Transactional
     @Modifying
-    @Query("DELETE FROM Comment c WHERE c.id = :commentId OR c.parent.id = :commentId")
+    @Query("DELETE FROM Comment c WHERE c.id = :commentId OR c.comment.id = :commentId")
     void deleteWithChildren(@Param("commentId") Long commentId);
+
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
@@ -19,7 +19,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Transactional
     @Modifying
-    @Query("DELETE FROM Comment c WHERE c.id = :commentId OR c.comment.id = :commentId")
-    void deleteWithChildren(@Param("commentId") Long commentId);
+    @Query("DELETE FROM Comment c WHERE c.comment.id = :commentId")
+    void deleteChildren(@Param("commentId") Long commentId);
 
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
@@ -1,9 +1,13 @@
 package com.clokey.server.domain.history.domain.repository;
 
 import com.clokey.server.domain.history.domain.entity.Comment;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,4 +17,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByCommentId(Long parentId);
 
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.id = :commentId OR c.parent.id = :commentId")
+    void deleteWithChildren(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryRequestDTO.java
@@ -82,5 +82,16 @@ public class HistoryRequestDTO {
         String content;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateComment {
+
+        @CommentContentLength
+        @NotBlank
+        String content;
+    }
+
 
 }

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -60,6 +60,7 @@ public enum ErrorStatus implements BaseErrorCode {
     HISTORY_ALREADY_EXIST_FOR_DATE(HttpStatus.BAD_REQUEST,"HISTORY_4012","이미 기록이 존재하는 날짜입니다."),
     IMAGE_QUANTITY_OVER_HISTORY_IMAGE_LIMIT(HttpStatus.BAD_REQUEST,"HISTORY_4013","사진을 10개 넘게 업로드 할 수 없습니다."),
     NOT_MY_HISTORY(HttpStatus.BAD_REQUEST,"HISTORY_4014","사용자의 기록이 아닙니다"),
+    NOT_MY_COMMENT(HttpStatus.BAD_REQUEST,"HISTORY_4015","사용자의 댓글이 아닙니다"),
 
     //해시태그 에러
     NO_SUCH_HASHTAG_NAME(HttpStatus.BAD_REQUEST,"HASHTAG_4001","해당 이름의 해시태그가 존재하지 않습니다"),

--- a/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
@@ -41,6 +41,7 @@ public enum SuccessStatus implements BaseCode {
     HISTORY_COMMENT_CREATED(HttpStatus.CREATED,"HISTORY_201","성공적으로 댓글이 생성되었습니다."),
     HISTORY_UPDATED(HttpStatus.NO_CONTENT,"HISTORY_204","성공적으로 수정되었습니다"),
     HISTORY_COMMENT_DELETED(HttpStatus.NO_CONTENT,"HISTORY_204","댓글이 성공적으로 삭제되었습니다"),
+    HISTORY_COMMENT_UPDATED(HttpStatus.NO_CONTENT,"HISTORY_204","댓글이 성공적으로 수정되었습니다"),
 
     //알림 성공
     NOTIFICATION_SUCCESS(HttpStatus.OK, "NOTIFICATION_200", "성공적으로 조회되었습니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
@@ -40,6 +40,7 @@ public enum SuccessStatus implements BaseCode {
     HISTORY_LIKE_STATUS_CHANGED(HttpStatus.OK,"HISTORY_200","좋아요 상태가 성공적으로 변경되었습니다."),
     HISTORY_COMMENT_CREATED(HttpStatus.CREATED,"HISTORY_201","성공적으로 댓글이 생성되었습니다."),
     HISTORY_UPDATED(HttpStatus.NO_CONTENT,"HISTORY_204","성공적으로 수정되었습니다"),
+    HISTORY_COMMENT_DELETED(HttpStatus.NO_CONTENT,"HISTORY_204","댓글이 성공적으로 삭제되었습니다"),
 
     //알림 성공
     NOTIFICATION_SUCCESS(HttpStatus.OK, "NOTIFICATION_200", "성공적으로 조회되었습니다."),


### PR DESCRIPTION
## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #88 

## 🌱 PR 요약
-댓글의 수정과 삭제를 구현 했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->

###기능
- 댓글이 삭제될 경우 대댓글들이 모두 삭제됩니다.
- 댓글을 수정할 수 있습니다

###예외
- 나의 댓글이 아닌 경우 삭제 또는 수정이 불가합니다.
- 수정할 경우 50글자를 넘을 수 없습니다.


## 📸 스크린샷
- 성공(수정)
<img width="670" alt="스크린샷 2025-01-27 오후 5 48 45" src="https://github.com/user-attachments/assets/bbac25c8-63c0-478f-835d-3e773f112cc4" />

- 성공(삭제)
<img width="670" alt="스크린샷 2025-01-27 오후 5 51 45" src="https://github.com/user-attachments/assets/3d264c00-4842-481c-af37-ec8a0eaba489" />

- 실패( 나의 댓글이 아닌 경우)
<img width="670" alt="스크린샷 2025-01-27 오후 5 52 36" src="https://github.com/user-attachments/assets/372a24a4-a755-40a3-924a-54a6d0521f02" />

- 싪패(50자 이상의 댓글로 수정하려 하는 경우)
<img width="670" alt="스크린샷 2025-01-27 오후 5 53 27" src="https://github.com/user-attachments/assets/ad78dc74-566c-4a90-bedf-cb5154bff76d" />


## ❗️리뷰어들께
