### PR TITLE
[Feat/#92] 기록 삭제 API 구현

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -61,7 +61,8 @@ jobs:
           username: ubuntu
           host: ${{ secrets.EC2_HOST }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          script: |  
+          script: |
+            echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
             sudo docker pull yongjun0511/clokey-docker:develop-latest 
             sudo chmod +x /home/ubuntu/cicd/deploy.sh
             sudo /home/ubuntu/cicd/deploy.sh

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -41,10 +41,11 @@ jobs:
         run: |
           docker build -t yongjun0511/clokey-docker:develop-latest .
 
-      - name: Push Docker Image
+      - name: Push Docker Image And Pull
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker push yongjun0511/clokey-docker:develop-latest 
+          docker pull yongjun0511/clokey-docker:develop-latest 
 
       - name: Copy docker-compose file to remote
         uses: appleboy/scp-action@v0.1.3

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -41,11 +41,12 @@ jobs:
         run: |
           docker build -t yongjun0511/clokey-docker:develop-latest .
 
-      - name: Push Docker Image And Pull
+      - name: Push Docker Image And update
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker push yongjun0511/clokey-docker:develop-latest 
-          docker pull yongjun0511/clokey-docker:develop-latest 
+          docker rmi yongjun0511/clokey-docker:develop-latest
+          docker pull yongjun0511/clokey-docker:develop-latest
 
       - name: Copy docker-compose file to remote
         uses: appleboy/scp-action@v0.1.3

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -45,8 +45,6 @@ jobs:
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker push yongjun0511/clokey-docker:develop-latest 
-          docker rmi yongjun0511/clokey-docker:develop-latest
-          docker pull yongjun0511/clokey-docker:develop-latest
 
       - name: Copy docker-compose file to remote
         uses: appleboy/scp-action@v0.1.3
@@ -63,7 +61,8 @@ jobs:
           username: ubuntu
           host: ${{ secrets.EC2_HOST }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
+          script: |  
+            sudo docker pull yongjun0511/clokey-docker:develop-latest 
             sudo chmod +x /home/ubuntu/cicd/deploy.sh
             sudo /home/ubuntu/cicd/deploy.sh
             

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -223,7 +223,7 @@ public class HistoryRestController {
     })
     public BaseResponse<Void> deleteHistory(
             @RequestParam Long memberId,
-            @PathVariable Long historyId
+            @PathVariable @HistoryExist Long historyId
     ) {
 
         historyService.deleteHistory(historyId,memberId);

--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -216,4 +216,20 @@ public class HistoryRestController {
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_COMMENT_UPDATED,null);
     }
 
+    @DeleteMapping(value = "/{historyId}")
+    @Operation(summary = "기록을 삭제하는 API", description = "Path Parameter로 history Id를 입력해주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HISTORY_204", description = "기록이 성공적으로 삭제되었습니다."),
+    })
+    public BaseResponse<Void> deleteHistory(
+            @RequestParam Long memberId,
+            @PathVariable Long historyId
+    ) {
+
+        historyService.deleteHistory(historyId,memberId);
+
+        return BaseResponse.onSuccess(SuccessStatus.HISTORY_DELETED,null);
+    }
+
+
 }

--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
@@ -21,4 +21,6 @@ public interface CommentRepositoryService {
     void deleteChildren(Long commentId);
 
     void deleteById(Long commentId);
+
+    void deleteAllComments(Long HistoryId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
@@ -55,4 +55,10 @@ public class CommentRepositoryServiceImpl implements CommentRepositoryService{
         commentRepository.deleteById(commentId);
     }
 
+    @Override
+    public void deleteAllComments(Long historyId) {
+        commentRepository.deleteRepliesByHistoryId(historyId);
+        commentRepository.deleteParentCommentsByHistoryId(historyId);
+    }
+
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
@@ -17,4 +17,6 @@ public interface HashtagHistoryRepositoryService {
     void addHashtagHistory(Hashtag hashtag, History history);
 
     void deleteHashtagHistory(Hashtag hashtag, History history);
+
+    void deleteAllByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
@@ -46,4 +46,9 @@ public class HashtagHistoryRepositoryServiceImpl implements HashtagHistoryReposi
     public void deleteHashtagHistory(Hashtag hashtag, History history) {
         hashtagHistoryRepository.deleteByHashtagAndHistory(hashtag, history);
     }
+
+    @Override
+    public void deleteAllByHistoryId(Long historyId) {
+        hashtagHistoryRepository.deleteAllByHistoryId(historyId);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryService.java
@@ -2,6 +2,9 @@ package com.clokey.server.domain.history.application;
 
 import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.history.domain.entity.History;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,4 +17,8 @@ public interface HistoryClothRepositoryService {
     List<Long> findClothIdsByHistoryId(Long historyId);
 
     void deleteAllByClothId(Long clothId);
+
+    List<Cloth> findAllClothByHistoryId(Long historyId);
+
+    void deleteAllByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
@@ -7,6 +7,9 @@ import com.clokey.server.domain.history.domain.repository.HistoryClothRepository
 import com.clokey.server.domain.history.domain.repository.HistoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -40,5 +43,15 @@ public class HistoryClothRepositoryServiceImpl implements HistoryClothRepository
     @Override
     public void deleteAllByClothId(Long clothId){
         historyClothRepository.deleteAllByClothId(clothId);
+    }
+
+    @Override
+    public List<Cloth> findAllClothByHistoryId(Long historyId) {
+        return historyClothRepository.findAllClothsByHistoryId(historyId);
+    }
+
+    @Override
+    public void deleteAllByHistoryId(Long historyId) {
+        historyClothRepository.deleteAllByHistoryId(historyId);
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -22,4 +22,6 @@ public interface HistoryRepositoryService {
     boolean checkHistoryExistOfDate(LocalDate date, Long memberId);
 
     History getHistoryOfDate(LocalDate date, Long memberId);
+
+    void deleteById(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
@@ -60,4 +60,9 @@ public class HistoryRepositoryServiceImpl implements HistoryRepositoryService {
         return historyRepository.findByHistoryDateAndMember_Id(date,memberId)
                 .orElseThrow(()-> new DatabaseException(ErrorStatus.NO_HISTORY_FOR_DATE));
     }
+
+    @Override
+    public void deleteById(Long historyId) {
+        historyRepository.deleteById(historyId);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryService.java
@@ -27,4 +27,6 @@ public interface HistoryService {
     void deleteComment(Long commentId,Long memberId);
 
     void updateComment(HistoryRequestDTO.UpdateComment updateCommentRequest,Long commentId,Long memberId);
+
+    void deleteHistory(Long historyId, Long memberId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -236,6 +236,23 @@ public class HistoryServiceImpl implements HistoryService {
         commentToUpdate.updateContent(updateCommentRequest.getContent());
     }
 
+    @Override
+    @Transactional
+    public void deleteHistory(Long historyId, Long memberId) {
+        historyAccessibleValidator.validateMyHistory(historyId,memberId);
+
+        //댓글 지우기
+        commentRepositoryService.deleteAllComments(historyId);
+
+        //기록_옷 지우기
+        List<Cloth> cloths =historyClothRepositoryService.findAllClothByHistoryId(historyId);
+        cloths.forEach(Cloth::decreaseWearNum);
+        historyClothRepositoryService.deleteAllByHistoryId(historyId);
+
+
+
+    }
+
     private void validateMyComment(Long commentId, Long memberId) {
         Comment comment = commentRepositoryService.findById(commentId);
         if(!comment.getMember().getId().equals(memberId)){

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -255,8 +255,7 @@ public class HistoryServiceImpl implements HistoryService {
         //좋아요 기록 삭제
         memberLikeRepositoryService.deleteAllByHistoryId(historyId);
 
-
-
+        historyImageRepositoryService.deleteAllByHistoryId(historyId);
     }
 
     private void validateMyComment(Long commentId, Long memberId) {

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -255,7 +255,11 @@ public class HistoryServiceImpl implements HistoryService {
         //좋아요 기록 삭제
         memberLikeRepositoryService.deleteAllByHistoryId(historyId);
 
+        //기록 사진 삭제
         historyImageRepositoryService.deleteAllByHistoryId(historyId);
+
+        //기록 삭제
+        historyRepositoryService.deleteById(historyId);
     }
 
     private void validateMyComment(Long commentId, Long memberId) {

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -249,6 +249,12 @@ public class HistoryServiceImpl implements HistoryService {
         cloths.forEach(Cloth::decreaseWearNum);
         historyClothRepositoryService.deleteAllByHistoryId(historyId);
 
+        //기록-해시태그 지우기
+        hashtagHistoryRepositoryService.deleteAllByHistoryId(historyId);
+
+        //좋아요 기록 삭제
+        memberLikeRepositoryService.deleteAllByHistoryId(historyId);
+
 
 
     }

--- a/src/main/java/com/clokey/server/domain/history/application/MemberLikeRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/MemberLikeRepositoryService.java
@@ -4,11 +4,13 @@ import com.clokey.server.domain.history.domain.entity.MemberLike;
 
 public interface MemberLikeRepositoryService {
 
-    public int countByHistory_Id(Long historyId);
+    int countByHistory_Id(Long historyId);
 
-    public boolean existsByMember_IdAndHistory_Id(Long memberId, Long historyId);
+    boolean existsByMember_IdAndHistory_Id(Long memberId, Long historyId);
 
-    public void deleteByMember_IdAndHistory_Id(Long memberId, Long historyId);
+    void deleteByMember_IdAndHistory_Id(Long memberId, Long historyId);
 
-    public void save(MemberLike memberLike);
+    void save(MemberLike memberLike);
+
+    void deleteAllByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/MemberLikeRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/MemberLikeRepositoryServiceImpl.java
@@ -32,4 +32,9 @@ public class MemberLikeRepositoryServiceImpl implements MemberLikeRepositoryServ
     public void save(MemberLike memberLike) {
         memberLikeRepository.save(memberLike);
     }
+
+    @Override
+    public void deleteAllByHistoryId(Long historyId) {
+        memberLikeRepository.deleteAllByHistoryId(historyId);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
@@ -17,9 +17,22 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByCommentId(Long parentId);
 
+    //햐나의 댓글을 기준으로 대댓글을 삭제합니다.
     @Transactional
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.comment.id = :commentId")
     void deleteChildren(@Param("commentId") Long commentId);
+
+    //하나의 기록을 기준으로 대댓글을 모두 삭제합니다.
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Comment c WHERE c.history.id = :historyId AND c.comment IS NOT NULL")
+    void deleteRepliesByHistoryId(@Param("historyId") Long historyId);
+
+    //하나의 기록을 기준으로 댓글을 모두 삭제합니다.
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Comment c WHERE c.history.id = :historyId")
+    void deleteParentCommentsByHistoryId(@Param("historyId") Long historyId);
 
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagHistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagHistoryRepository.java
@@ -21,4 +21,9 @@ public interface HashtagHistoryRepository extends JpaRepository<HashtagHistory, 
     @Modifying
     @Query("DELETE FROM HashtagHistory hh WHERE hh.hashtag = :hashtag AND hh.history = :history")
     void deleteByHashtagAndHistory(@Param("hashtag") Hashtag hashtag, @Param("history") History history);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM HashtagHistory hh WHERE hh.history.id = :historyId")
+    void deleteAllByHistoryId(@Param("historyId") Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryClothRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryClothRepository.java
@@ -25,4 +25,13 @@ public interface HistoryClothRepository extends JpaRepository<HistoryCloth, Long
 
     @Query("SELECT hc.cloth.id FROM HistoryCloth hc WHERE hc.history.id = :historyId")
     List<Long> findClothIdsByHistoryId(@Param("historyId") Long historyId);
+
+    // 특정 HistoryId에 연결된 모든 Cloth 조회
+    @Query("SELECT hc.cloth FROM HistoryCloth hc WHERE hc.history.id = :historyId")
+    List<Cloth> findAllClothsByHistoryId(@Param("historyId") Long historyId);
+
+    // 특정 HistoryId에 연결된 모든 HistoryCloth 삭제
+    @Modifying
+    @Query("DELETE FROM HistoryCloth hc WHERE hc.history.id = :historyId")
+    void deleteAllByHistoryId(@Param("historyId") Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/MemberLikeRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/MemberLikeRepository.java
@@ -2,6 +2,9 @@ package com.clokey.server.domain.history.domain.repository;
 
 import com.clokey.server.domain.history.domain.entity.MemberLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
 
@@ -11,4 +14,7 @@ public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
 
     void deleteByMember_IdAndHistory_Id(Long memberId, Long historyId);
 
+    @Modifying  // 수정/삭제 작업을 나타냄
+    @Query("DELETE FROM MemberLike ml WHERE ml.history.id = :historyId")
+    void deleteAllByHistoryId(@Param("historyId") Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/notification/domain/entity/Notification.java
+++ b/src/main/java/com/clokey/server/domain/notification/domain/entity/Notification.java
@@ -32,6 +32,7 @@ public class Notification extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
 
+    @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(15) DEFAULT 'NOT_READ'",nullable = false)
     private ReadStatus readStatus;
 }

--- a/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
@@ -43,6 +43,7 @@ public enum SuccessStatus implements BaseCode {
     HISTORY_UPDATED(HttpStatus.NO_CONTENT,"HISTORY_204","성공적으로 수정되었습니다"),
     HISTORY_COMMENT_DELETED(HttpStatus.NO_CONTENT,"HISTORY_204","댓글이 성공적으로 삭제되었습니다"),
     HISTORY_COMMENT_UPDATED(HttpStatus.NO_CONTENT,"HISTORY_204","댓글이 성공적으로 수정되었습니다"),
+    HISTORY_DELETED(HttpStatus.NO_CONTENT,"HISTORY_204","기록이 성공적으로 삭제되었습니다"),
 
     //알림 성공
     NOTIFICATION_SUCCESS(HttpStatus.OK, "NOTIFICATION_200", "성공적으로 조회되었습니다."),


### PR DESCRIPTION
## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #92 

## 🌱 PR 요약
- 기록을 삭제하는 API

## 🛠 작업 내용
- 기록과 관련된 댓글이 전부 삭제됩니다. 
- 기록이 삭제되면서 기록에 포함된 옷의 착용 횟수가 내려갑니다. 
- 기록과 관련된 해시태그_기록이 전부 삭제 됩니다. 
- 기록과 관련된 사진이 모두 삭제됩니다.
- 좋아요도 테이블에서 기록과 관련된 좋아요가 전부 삭제됩니다.
- 기록-옷 테이블에서 기록과 관련된 row들이 전부 삭제됩니다. 

## 📸 스크린샷
<img width="728" alt="스크린샷 2025-01-28 오후 5 17 40" src="https://github.com/user-attachments/assets/a30c9449-153d-481f-870a-804291717b51" />

## ❗️리뷰어들께