### PR TITLE
[feat/#102] 토큰에서 정보 추출 어노테이션 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
+++ b/src/main/java/com/clokey/server/domain/history/api/HistoryRestController.java
@@ -3,6 +3,8 @@ package com.clokey.server.domain.history.api;
 import com.clokey.server.domain.history.application.HistoryService;
 import com.clokey.server.domain.history.dto.HistoryRequestDTO;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
+import com.clokey.server.domain.member.domain.entity.Member;
+import com.clokey.server.domain.member.exception.annotation.AuthUser;
 import com.clokey.server.global.error.exception.annotation.CheckPage;
 import com.clokey.server.domain.history.exception.annotation.HistoryExist;
 import com.clokey.server.domain.history.exception.annotation.HistoryImageQuantityLimit;
@@ -218,11 +220,11 @@ public class HistoryRestController {
             @Parameter(name = "historyId", description = "삭제하고자 하는 기록의 ID입니다.")
     })
     public BaseResponse<Void> deleteHistory(
-            @RequestParam Long memberId,
+            @Parameter(name = "user", hidden = true) @AuthUser Member member,
             @PathVariable @HistoryExist Long historyId
     ) {
 
-        historyService.deleteHistory(historyId, memberId);
+        historyService.deleteHistory(historyId, member.getId());
 
         return BaseResponse.onSuccess(SuccessStatus.HISTORY_DELETED, null);
     }

--- a/src/main/java/com/clokey/server/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/clokey/server/domain/member/domain/entity/Member.java
@@ -71,6 +71,10 @@ public class Member extends BaseEntity {
     @Column(nullable = true, unique = true)
     private String refreshToken;
 
+    @Column(nullable = true, unique = true)
+    private String accessToken;
+
+
 
     //필요한 양방향 매핑을 제외하고 삭제해주세요.
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
@@ -96,5 +100,10 @@ public class Member extends BaseEntity {
 
     public void updateRegisterStatus(RegisterStatus registerStatus) {
         this.registerStatus = registerStatus;
+    }
+
+    public void updateToken(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/clokey/server/domain/member/exception/annotation/AuthUser.java
+++ b/src/main/java/com/clokey/server/domain/member/exception/annotation/AuthUser.java
@@ -1,0 +1,10 @@
+package com.clokey.server.domain.member.exception.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthUser {}

--- a/src/main/java/com/clokey/server/domain/member/exception/validator/AuthUserArgumentResolver.java
+++ b/src/main/java/com/clokey/server/domain/member/exception/validator/AuthUserArgumentResolver.java
@@ -1,0 +1,48 @@
+package com.clokey.server.domain.member.exception.validator;
+
+import com.clokey.server.domain.member.domain.entity.Member;
+import com.clokey.server.domain.member.exception.MemberException;
+import com.clokey.server.global.config.security.auth.PrincipalDetails;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory)
+            throws MemberException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null; // 로그인하지 않은 사용자
+        }
+
+        if (authentication.getPrincipal() instanceof PrincipalDetails principalDetails) {
+            return principalDetails.getMember();
+        }
+
+        throw new MemberException(ErrorStatus.NO_SUCH_MEMBER);
+    }
+}
+

--- a/src/main/java/com/clokey/server/global/config/WebConfig.java
+++ b/src/main/java/com/clokey/server/global/config/WebConfig.java
@@ -1,0 +1,35 @@
+package com.clokey.server.global.config;
+
+import java.util.List;
+
+import com.clokey.server.domain.member.exception.validator.AuthUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(false)
+                .maxAge(6000);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}
+

--- a/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.clokey.server.global.config.security;
 
 import com.clokey.server.global.config.security.jwt.JwtRequestFilter;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import com.clokey.server.global.error.exception.GeneralException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -66,23 +68,12 @@ public class SecurityConfig {
 
     private void configureExceptionHandling(HttpSecurity http) throws Exception {
         http.exceptionHandling(exceptions -> exceptions
-                .accessDeniedHandler(accessDeniedHandler())
                 .authenticationEntryPoint((request, response, authException) -> {
                     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                     response.setContentType("application/json");
                     response.setCharacterEncoding("UTF-8");
-                    response.getWriter().write("{ \"error\": \"Unauthorized\", \"message\": \"인증이 필요합니다.\" }");
+                    response.getWriter().write("{ \"isSuccess\": false, \"code\": \"COMMON401\", \"message\": \"인증이 필요합니다.\" }");
                 })
         );
-    }
-
-    @Bean
-    public AccessDeniedHandler accessDeniedHandler() {
-        return (request, response, accessDeniedException) -> {
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-            response.setContentType("application/json");
-            response.setCharacterEncoding("UTF-8");
-            response.getWriter().write("{ \"error\": \"Access Denied\", \"message\": \"권한이 없습니다.\", \"path\": \"" + request.getRequestURI() + "\" }");
-        };
     }
 }

--- a/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.clokey.server.global.config.security;
 
+import com.clokey.server.global.config.security.jwt.JwtRequestFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtRequestFilter jwtRequestFilter;
     private static final String[] SECURITY_ALLOW_ARRAY  = {
             "/api/login",
             "/health",
@@ -29,10 +32,8 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/login",
             "/refresh",
-            "/actuator/prometheus",
             "/ws/**",
-            "/topic/**",
-            "/**"
+            "/topic/**"
     };
 
     @Bean
@@ -50,6 +51,8 @@ public class SecurityConfig {
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         configureAuthorization(http);
         configureExceptionHandling(http);
+
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/clokey/server/global/config/security/auth/PrincipalDetails.java
+++ b/src/main/java/com/clokey/server/global/config/security/auth/PrincipalDetails.java
@@ -1,0 +1,60 @@
+package com.clokey.server.global.config.security.auth;
+
+import com.clokey.server.domain.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class PrincipalDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_USER");
+
+        return roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getId().toString();
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/clokey/server/global/config/security/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/clokey/server/global/config/security/auth/PrincipalDetailsService.java
@@ -1,0 +1,30 @@
+package com.clokey.server.global.config.security.auth;
+
+import com.clokey.server.domain.member.application.MemberRepositoryService;
+import com.clokey.server.domain.member.domain.entity.Member;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import com.clokey.server.global.error.exception.DatabaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final MemberRepositoryService memberRepositoryService;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member =
+                memberRepositoryService
+                        .findMemberByEmail(email)
+                        .orElseThrow(() -> new DatabaseException(ErrorStatus.NO_SUCH_MEMBER));
+
+        return new PrincipalDetails(member);
+    }
+}

--- a/src/main/java/com/clokey/server/global/config/security/jwt/JwtConfig.java
+++ b/src/main/java/com/clokey/server/global/config/security/jwt/JwtConfig.java
@@ -1,4 +1,4 @@
-package com.clokey.server.global.config;
+package com.clokey.server.global.config.security.jwt;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/clokey/server/global/config/security/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/clokey/server/global/config/security/jwt/JwtRequestFilter.java
@@ -1,0 +1,58 @@
+package com.clokey.server.global.config.security.jwt;
+
+import java.io.IOException;
+
+import com.clokey.server.domain.member.application.AuthService;
+import com.clokey.server.global.config.security.auth.PrincipalDetails;
+import com.clokey.server.global.config.security.auth.PrincipalDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private final AuthService authService;
+    private final PrincipalDetailsService principalDetailsService;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && authService.validateJwtToken(token)) {
+            String email = authService.extractEmailFromToken(token);
+
+            PrincipalDetails principalDetails = (PrincipalDetails) principalDetailsService.loadUserByUsername(email);
+
+            if (principalDetails != null) {
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                principalDetails, null, principalDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication); // SecurityContext에 저장
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #102 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 토큰에서 정보 추출하는 AuthUser 어노테이션을 구현하였습니다

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- JwtRequestFilter가 요청을 가로채 JWT 토큰을 추출하고 검증합니다. 또한 SecurityContext에 사용자 정보를 저장합니다.
- PrincipalDetails는 UserDetails 구현체로 사용자 정보 담고 가져올 때 사용합니다.
- PrincipalDetailsService에서는 DB에서 Member를 조회하고 PrincipalDetails로 변환합니다. 
- AuthUser는 SecurityContext에서 Member를 가져와서 사용가능하게 합니다.
- 로그인 시 AccessToken과 RefreshToken 모두 저장하도록 변경하였습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
- 인증 안 할 경우
![image](https://github.com/user-attachments/assets/8b99747f-67f0-44f5-ad6c-d335c1ddbcfe)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
###  swagger 사용 방법입니다. 로그인, refresh 토큰 재발급 제외한 모든 api 이용하기 위해서는 아래와 같이 인증을 하고 사용해야 합니다.

1. Authorize 버튼 누르기
![image](https://github.com/user-attachments/assets/2e41baab-d6cf-48d9-8945-90602ad52f7d)

2. 여기에 토큰 입력하기
![image](https://github.com/user-attachments/assets/5b5fe071-8568-4831-a671-b20fb3135b0d)

3. 토큰 입력후 Authorize 버튼 누르기
![image](https://github.com/user-attachments/assets/760ba7b5-72ae-4dc3-a391-975b63f9600e)

4. api 테스트하기 ~
![image](https://github.com/user-attachments/assets/1047139f-c966-4b2e-85cb-3614b04b281a)


### 어노테이션 AuthUser 사용방법입니다. 
1. memberId 줄을 대체해줍니다.
`@Parameter(name = "user", hidden = true) @AuthUser Member member,`
![image](https://github.com/user-attachments/assets/210f9508-60f9-44ce-bfae-019128c92d51)


2. Member객체를 반환하기 때문에 기존의 memberId 사용하려면 member.getId() 추가해주시면 됩니다.
![image](https://github.com/user-attachments/assets/012b4040-7f6a-4f95-9988-43f7d56de488)


### 혹시라도 인증 필요 없는 api가 있다면, SecurityConfig에서 SECURITY_ALLOW_ARRAY에 api uri를 추가해주시면 됩니다.
![image](https://github.com/user-attachments/assets/e6d1c8d8-299b-4a6a-8165-f0fc7e796fa4)

