### PR TITLE
[feat/#111] token api

### DIFF
--- a/src/main/java/com/clokey/server/domain/member/api/AuthController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/AuthController.java
@@ -49,8 +49,8 @@ public class AuthController {
     }
 
 
-    @PostMapping("/refresh-token")
-    public ResponseEntity<AuthDTO.TokenResponse> refreshAccessToken(@RequestBody AuthDTO.RefreshTokenRequest request) {
+    @PostMapping("/reissue-token")
+    public ResponseEntity<AuthDTO.TokenResponse> reissueToken(@RequestBody AuthDTO.RefreshTokenRequest request) {
 
         return authService.refreshAccessToken(request.getRefreshToken());
     }

--- a/src/main/java/com/clokey/server/domain/member/api/AuthController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/AuthController.java
@@ -50,8 +50,9 @@ public class AuthController {
 
 
     @PostMapping("/refresh-token")
-    public ResponseEntity<AuthDTO.TokenResponse> refreshAccessToken(@RequestBody String refreshToken) {
-        return authService.refreshAccessToken(refreshToken);
+    public ResponseEntity<AuthDTO.TokenResponse> refreshAccessToken(@RequestBody AuthDTO.RefreshTokenRequest request) {
+
+        return authService.refreshAccessToken(request.getRefreshToken());
     }
 }
 

--- a/src/main/java/com/clokey/server/domain/member/api/AuthController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/AuthController.java
@@ -47,6 +47,12 @@ public class AuthController {
         return ResponseEntity.status(responseEntity.getStatusCode())
                 .body(BaseResponse.onSuccess(successStatus, responseEntity.getBody()));
     }
+
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<AuthDTO.TokenResponse> refreshAccessToken(@RequestBody String refreshToken) {
+        return authService.refreshAccessToken(refreshToken);
+    }
 }
 
 

--- a/src/main/java/com/clokey/server/domain/member/api/AuthController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/AuthController.java
@@ -50,9 +50,11 @@ public class AuthController {
 
 
     @PostMapping("/reissue-token")
-    public ResponseEntity<AuthDTO.TokenResponse> reissueToken(@RequestBody AuthDTO.RefreshTokenRequest request) {
+    public BaseResponse<AuthDTO.TokenResponse> reissueToken(@RequestBody AuthDTO.RefreshTokenRequest request) {
 
-        return authService.refreshAccessToken(request.getRefreshToken());
+        AuthDTO.TokenResponse response = authService.refreshAccessToken(request.getRefreshToken());
+        return BaseResponse.onSuccess(SuccessStatus.LOGIN_UPDATED, response);
+
     }
 }
 

--- a/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
@@ -50,12 +50,14 @@ public class MemberRestController {
     @Operation(summary = "회원 조회 API", description = "다른 회원의 프로필을 조회하는 API입니다.")
     @GetMapping("users/{clokey_id}")
     public BaseResponse<Object> getUser(
+            @AuthUser Member currentUser, // 현재 로그인한 사용자 추가
             @IdValid @PathVariable("clokey_id") String clokeyId) {
 
-        MemberDTO.GetUserRP response = getUserQueryService.getUser(clokeyId);
+        MemberDTO.GetUserRP response = getUserQueryService.getUser(clokeyId, currentUser);
 
         return BaseResponse.onSuccess(SuccessStatus.MEMBER_SUCCESS, response);
     }
+
 
 
     @Operation(summary = "팔로우 조회 API", description = "내가 다른 사용자를 팔로우하고있는지 확인하는 API입니다.")

--- a/src/main/java/com/clokey/server/domain/member/application/AuthService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/AuthService.java
@@ -15,4 +15,6 @@ public interface AuthService {
     // 카카오 사용자 정보 조회 및 DB 저장 메서드 추가
     ResponseEntity<AuthDTO.TokenResponse> authenticateKakaoUser(String kakaoAccessToken);
     AuthDTO.KakaoUserResponse getUserInfoFromKakao(String kakaoAccessToken);
+
+    public ResponseEntity<AuthDTO.TokenResponse> refreshAccessToken(String refreshToken);
 }

--- a/src/main/java/com/clokey/server/domain/member/application/AuthService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/AuthService.java
@@ -16,5 +16,5 @@ public interface AuthService {
     ResponseEntity<AuthDTO.TokenResponse> authenticateKakaoUser(String kakaoAccessToken);
     AuthDTO.KakaoUserResponse getUserInfoFromKakao(String kakaoAccessToken);
 
-    public ResponseEntity<AuthDTO.TokenResponse> refreshAccessToken(String refreshToken);
+    public AuthDTO.TokenResponse refreshAccessToken(String refreshToken);
 }

--- a/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
@@ -87,14 +87,6 @@ public class AuthServiceImpl implements AuthService {
         return claims.get("email", String.class);
     }
 
-    private Long extractIdFromToken(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(secretKey)  // 비밀키로 서명된 토큰 파싱
-                .parseClaimsJws(token)
-                .getBody();
-        return claims.get("id", Long.class);  // Id를 클레임에서 추출
-    }
-
 
 
     @Transactional
@@ -196,8 +188,6 @@ public class AuthServiceImpl implements AuthService {
 
         // 리프레시 토큰에서 userId 추출
         String email = extractEmailFromToken(refreshToken);
-
-        System.out.println("Email extracted from refresh token: " + email);
 
         // DB에서 사용자 정보 조회 (Member가 null일 수 있음)
         Member member = memberRepositoryService.findMemberByEmail(email).orElse(null);

--- a/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
@@ -175,7 +175,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Transactional
     @Override
-    public ResponseEntity<AuthDTO.TokenResponse> refreshAccessToken(String refreshToken) {
+    public AuthDTO.TokenResponse refreshAccessToken(String refreshToken) {
 
         if (isRefreshTokenExpired(refreshToken)) {
             throw new MemberException(ErrorStatus.EXPIRED_REFRESH_TOKEN);  // 리프레시 토큰 만료
@@ -215,7 +215,7 @@ public class AuthServiceImpl implements AuthService {
                 member.getRegisterStatus()
         );
 
-        return ResponseEntity.ok(tokenResponse);  // 200 OK
+        return tokenResponse;
     }
 
     private boolean isRefreshTokenExpired(String refreshToken) {

--- a/src/main/java/com/clokey/server/domain/member/application/GetUserQueryService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/GetUserQueryService.java
@@ -1,9 +1,10 @@
 package com.clokey.server.domain.member.application;
 
+import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.member.dto.MemberDTO;
 
 public interface GetUserQueryService {
 
-    MemberDTO.GetUserRP getUser(String clokeyId);
+    MemberDTO.GetUserRP getUser(String clokeyId, Member currentUser); // 로그인한 사용자 정보 추가
 
 }

--- a/src/main/java/com/clokey/server/domain/member/converter/GetUserConverter.java
+++ b/src/main/java/com/clokey/server/domain/member/converter/GetUserConverter.java
@@ -15,6 +15,7 @@ public class GetUserConverter {
                 .followingCount(followingCount)
                 .nickname(member.getNickname())
                 .bio(member.getBio())
+                .profileBackImageUrl(member.getProfileBackImageUrl())
                 .visibility(member.getVisibility().toString())
                 .isFollowing(isFollowing) // 추가된 필드 반영
                 .build();

--- a/src/main/java/com/clokey/server/domain/member/converter/GetUserConverter.java
+++ b/src/main/java/com/clokey/server/domain/member/converter/GetUserConverter.java
@@ -6,7 +6,7 @@ import com.clokey.server.domain.member.dto.MemberDTO;
 
 public class GetUserConverter {
 
-    public static MemberDTO.GetUserRP toGetUserResponseDTO(Member member, Long recordCount, Long followerCount, Long followingCount) {
+    public static MemberDTO.GetUserRP toGetUserResponseDTO(Member member, Long recordCount, Long followerCount, Long followingCount, boolean isFollowing) {
         return MemberDTO.GetUserRP.builder()
                 .clokeyId(member.getClokeyId())
                 .profileImageUrl(member.getProfileImageUrl())
@@ -16,8 +16,10 @@ public class GetUserConverter {
                 .nickname(member.getNickname())
                 .bio(member.getBio())
                 .visibility(member.getVisibility().toString())
+                .isFollowing(isFollowing) // 추가된 필드 반영
                 .build();
     }
 }
+
 
 

--- a/src/main/java/com/clokey/server/domain/member/dto/AuthDTO.java
+++ b/src/main/java/com/clokey/server/domain/member/dto/AuthDTO.java
@@ -52,7 +52,7 @@ public class AuthDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public class RefreshTokenRequest {
+    public static class RefreshTokenRequest {
         private String refreshToken;
     }
 

--- a/src/main/java/com/clokey/server/domain/member/dto/AuthDTO.java
+++ b/src/main/java/com/clokey/server/domain/member/dto/AuthDTO.java
@@ -2,8 +2,7 @@ package com.clokey.server.domain.member.dto;
 
 import com.clokey.server.domain.model.entity.enums.RegisterStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -49,5 +48,13 @@ public class AuthDTO {
         private String refreshToken;
         RegisterStatus registerStatus;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public class RefreshTokenRequest {
+        private String refreshToken;
+    }
+
 }
 

--- a/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
@@ -24,6 +24,7 @@ public class MemberDTO {
         Long followingCount;
         String nickname;
         String bio;
+        String profileBackImageUrl;
         String visibility;
         boolean isFollowing;
     }

--- a/src/main/java/com/clokey/server/domain/term/api/TermRestController.java
+++ b/src/main/java/com/clokey/server/domain/term/api/TermRestController.java
@@ -15,16 +15,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users/{userId}/terms")
 public class TermRestController {
 
     private final TermCommandService termCommandService;
 
     @Operation(summary = "약관 동의 API", description = "약관동의하는 API입니다.")
-    @PostMapping
+    @PostMapping("/users/terms")
     public BaseResponse<TermResponseDTO> termAgree(
             @Parameter(name = "user",hidden = true) @AuthUser Member member,
             @EssentialTermAgree @RequestBody @Valid TermRequestDTO.Join request) {
@@ -34,6 +35,16 @@ public class TermRestController {
 
         // 성공 응답 반환
         return BaseResponse.onSuccess(SuccessStatus.MEMBER_ACTION_CREATED, response);
+    }
+
+    @Operation(summary = "모든 약관 조회 API", description = "모든 약관을 조회하는 API입니다.")
+    @GetMapping("/users/terms")
+    public BaseResponse<List<TermResponseDTO.TermList>> getTerms() {
+        // 약관 목록 조회
+        List<TermResponseDTO.TermList> terms = termCommandService.getTerms();
+
+        // 성공 응답 반환
+        return BaseResponse.onSuccess(SuccessStatus.MEMBER_SUCCESS, terms);
     }
 }
 

--- a/src/main/java/com/clokey/server/domain/term/application/TermCommandService.java
+++ b/src/main/java/com/clokey/server/domain/term/application/TermCommandService.java
@@ -3,6 +3,10 @@ package com.clokey.server.domain.term.application;
 import com.clokey.server.domain.term.dto.TermRequestDTO;
 import com.clokey.server.domain.term.dto.TermResponseDTO;
 
+import java.util.List;
+
 public interface TermCommandService {
     TermResponseDTO joinTerm(Long userId, TermRequestDTO.Join request);
+    List<TermResponseDTO.TermList> getTerms();  // 모든 약관 조회 메서드 추가
 }
+

--- a/src/main/java/com/clokey/server/domain/term/application/TermCommandServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/term/application/TermCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.clokey.server.domain.term.application;
 import com.clokey.server.domain.member.application.MemberRepositoryService;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.model.entity.enums.RegisterStatus;
+import com.clokey.server.domain.term.converter.TermConverter;
 import com.clokey.server.domain.term.domain.entity.Term;
 import com.clokey.server.domain.term.domain.entity.MemberTerm;
 import com.clokey.server.domain.term.domain.repository.MemberTermRepository;
@@ -72,4 +73,19 @@ public class TermCommandServiceImpl implements TermCommandService {
                 .terms(termResponses)
                 .build();
     }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TermResponseDTO.TermList> getTerms() {
+        List<Term> terms = termRepository.findAll();  // 모든 약관 조회
+
+        List<TermResponseDTO.TermList> termList = new ArrayList<>();
+        for (Term term : terms) {
+            termList.add(TermConverter.toTermListDto(term));
+        }
+
+        return termList;
+    }
+
 }

--- a/src/main/java/com/clokey/server/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/clokey/server/domain/term/converter/TermConverter.java
@@ -12,5 +12,15 @@ public class TermConverter {
                 .agreed(agreed)
                 .build();
     }
+
+    // Term -> TermResponseDTO.TermList 변환
+    public static TermResponseDTO.TermList toTermListDto(Term term) {
+        return TermResponseDTO.TermList.builder()
+                .termId(term.getId())
+                .title(term.getTitle())  // 약관 제목
+                .content(term.getBody())  // 약관 내용
+                .optional(term.getOptional())  // optional이 아니면 필수 약관
+                .build();
+    }
 }
 

--- a/src/main/java/com/clokey/server/domain/term/dto/TermResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/term/dto/TermResponseDTO.java
@@ -24,4 +24,16 @@ public class TermResponseDTO {
         private Long termId;
         private Boolean agreed;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TermList {
+        private Long termId;
+        private String title;
+        private String content;
+        private boolean optional;
+    }
+
 }

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -95,6 +95,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MISSING_LOGIN_TYPE(HttpStatus.BAD_REQUEST,"LOGIN_4002","로그인 타입이 누락되었습니다."),
     INVALID_LOGIN_TYPE(HttpStatus.BAD_REQUEST,"LOGIN_4003","잘못된 로그인 타입입니다."),
     LOGIN_FAILED(HttpStatus.BAD_REQUEST,"LOGIN_4004","로그인에 실패했습니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"LOGIN_4005","리프레시 토큰이 만료되었습니다. 다시 로그인 하세요."),
 
     ;
 

--- a/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/SuccessStatus.java
@@ -63,7 +63,8 @@ public enum SuccessStatus implements BaseCode {
 
     //로그인 성공
     LOGIN_SUCCESS(HttpStatus.OK, "LOGIN_200", "로그인에 성공하였습니다."),
-    LOGIN_CREATED(HttpStatus.CREATED, "LOGIN_201", "회원가입과 로그인에 성공하였습니다.");
+    LOGIN_CREATED(HttpStatus.CREATED, "LOGIN_201", "회원가입과 로그인에 성공하였습니다."),
+    LOGIN_UPDATED(HttpStatus.NO_CONTENT, "LOGIN_204", "로그인 정보가 성공적으로 수정되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #111 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 어세스토큰 만료시 리프레쉬토큰으로 어세스토큰/리프레쉬토큰 새로발급
- 리프레쉬토큰도 만료되었으면 재로그인하라는 메시지
- 모든 약관의 id, 제목, 내용, 선택여부 조회하는 약관조회api구현
- 회원조회시 내가 팔로우하고 있는 회원인지 확인하는 로직 추가
- 기존 약관동의 api 엔드포인트 수정

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
약관조회
![image](https://github.com/user-attachments/assets/da4dc032-e9bc-4d9d-9673-d26550330913)
토큰 재발급
![image](https://github.com/user-attachments/assets/30f5621b-9d18-4eaf-a2e0-69aa2c5203ca)

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
토큰 재발급시 requestBody로 refreshToken 받게끔 했는데 다른 방법이 나을까요?