### PR TITLE
[feat/#125] elastiCache로 redis 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 처리 라이브러리
 
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/clokey/server/ServerApplication.java
+++ b/src/main/java/com/clokey/server/ServerApplication.java
@@ -2,11 +2,12 @@ package com.clokey.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.PropertySource;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@ConfigurationProperties("spring.data.redis")
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/clokey/server/domain/RedisService.java
+++ b/src/main/java/com/clokey/server/domain/RedisService.java
@@ -1,0 +1,37 @@
+package com.clokey.server.domain;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // 예시 매서드를 만들어 놓았습니다.
+    // 유저의 validCode를 Redis에 저장
+    public String redisString(String validCode) {
+        ValueOperations<String, String> operations = redisTemplate.opsForValue();
+        String key = "validCode:" + validCode;
+        operations.set(key, validCode, 1, TimeUnit.DAYS);  // 만료 시간 1일 설정
+        String redis = operations.get(key);
+        log.info("validCode = {}", redis);
+        return redis;
+    }
+
+    // 유저의 세션 데이터를 Redis에서 가져오기
+    public String getSessionData(String userId) {
+        ValueOperations<String, String> operations = redisTemplate.opsForValue();
+        String key = "sessionData:" + userId;
+        String redis = operations.get(key);
+        log.info("Retrieved sessionData for userId = {}: {}", userId, redis);
+        return redis;
+    }
+}

--- a/src/main/java/com/clokey/server/global/config/RedisConfig.java
+++ b/src/main/java/com/clokey/server/global/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.clokey.server.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableConfigurationProperties(RedisProperties.class)
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties properties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(properties.getHost(), properties.getPort());
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/test/java/com/clokey/server/domain/RedisServiceTest.java
+++ b/src/test/java/com/clokey/server/domain/RedisServiceTest.java
@@ -1,0 +1,72 @@
+package com.clokey.server.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class RedisServiceTest {
+
+    private RedisService redisService;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        // Mockito로 Mock 객체 생성
+        MockitoAnnotations.openMocks(this);
+        // RedisTemplate의 opsForValue() 메서드를 mock 객체로 설정
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        // RedisService 생성
+        redisService = new RedisService(redisTemplate);
+    }
+
+    @Test
+    void testGetSessionData() {
+        // 준비: Redis에서 "sessionData:user123" 값을 리턴한다고 설정
+        String userId = "user123";
+        String expectedSessionData = "sessionDataValue";
+        when(valueOperations.get("sessionData:" + userId)).thenReturn(expectedSessionData);
+
+        // 실행: getSessionData 메서드 호출
+        String sessionData = redisService.getSessionData(userId);
+
+        // 검증: 반환값이 예상한 세션 데이터와 일치하는지 확인
+        assertEquals(expectedSessionData, sessionData);
+
+        // 확인: Redis에서 "sessionData:user123" 키로 get()을 호출했는지 확인
+        verify(valueOperations).get("sessionData:" + userId);
+    }
+
+    @Test
+    void testGetSessionData_whenNotFound() {
+        // 준비: Redis에서 "sessionData:user123" 값이 없다고 설정
+        String userId = "user123";
+        when(valueOperations.get("sessionData:" + userId)).thenReturn(null);
+
+        // 실행: getSessionData 메서드 호출
+        String sessionData = redisService.getSessionData(userId);
+
+        // 검증: 값이 없으면 null이 반환되어야 함
+        assertNull(sessionData);
+
+        // 확인: Redis에서 "sessionData:user123" 키로 get()을 호출했는지 확인
+        verify(valueOperations).get("sessionData:" + userId);
+    }
+}


### PR DESCRIPTION
## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #125 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
-redis를 적용했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 로컬에서는 자체적으로 Redis를 설치하여 테스트를 진행하셔야 합니다.
- EC2에서는 ElastiCache에 연결됩니다.
- 설정해야하는 것들이 몇가지 있습니다.

## 📸 스크린샷
- Local에 각자 Redis를 설치해주셔야 합니다!
저는 Mac 이여서 Home Brew로 설치를 했는데 윈도우도 설치만 해주시면 됩니다. [🔗](https://inpa.tistory.com/entry/REDIS-%F0%9F%93%9A-Window10-%ED%99%98%EA%B2%BD%EC%97%90-Redis-%EC%84%A4%EC%B9%98%ED%95%98%EA%B8%B0)

- 설치후 별도의 비밀번호는 설정하지 않았습니다. 따라서, yml에도 별도의 redis 비밀번호가 기재되어 있지는 않습니다.
<img width="337" alt="스크린샷 2025-02-03 오후 7 34 15" src="https://github.com/user-attachments/assets/2d328def-9bdb-4681-bcb0-ed05f83c4d42" />

이 부분은 yml에서 Dev 프로파일 부분입니다(디폴트가 dev로 실행되기 때문).
이에 따라서 로컬의 환경에서는 host와 포트 설정만 되어 있고 redis만 설치되어 있다면 바로 작동가능합니다.

- 설치가 완료되고 위의 설치 링크에서 PING -> PONG 응답을 받고 redis가 정상작동하는 것을 확인했다면 Test 코드를 돌려봐주세요.
<img width="947" alt="스크린샷 2025-02-03 오후 7 36 55" src="https://github.com/user-attachments/assets/33a741db-5647-4021-ba69-2aa34a2c7ee3" />

테스트 코드가 잘 돌아간다면 로컬에서 설정이 완료되었습니다.

- Redis Service
<img width="947" alt="스크린샷 2025-02-03 오후 7 41 42" src="https://github.com/user-attachments/assets/01e0dba8-c43a-49a1-85b2-b7acd4a64cb8" />

특정 도메인에 넣기 애매해서 우선 밖에 놨습니다.

캐시가 필요한 부분에서는 필요한 매서드를 만들고 RedisService를 호출하여 사용하시면 됩니다.

예시로 매서드를 만들어 놓은 것은 테스트를 위해서 만들어놨기 때문에 우선은 삭제하지 말아주세요!

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- 로컬에서는 정상작동을 하는 것은 확인했지만, 배포 상태에서 테스트를 해보지는 못했습니다. 
- 개발 완료 후 PR 푸쉬를 하면 배포가 되고, 그 상태에서 Swagger를 이용해서 테스트를 해주시고 잘 작동하지 않으면 말씀해주세요 :)

- 캐시는 비용(시간적 비용+ 말 그대로 돈)이 비싸기 때문에 (하루 동안 추천되는 옷 API)나 (Home의 HOT 게시물..?) 정도만 사용하시는게 어떠신지... 구체적인 메서드 구현 방법은 예시를 완전히 따라하는 것보다 레퍼런스를 찾아서 만드시는 것을 추천합니다!