### PR TITLE
[refactor/#129] 폴더 생성 api 로직 수정

### DIFF
--- a/src/main/java/com/clokey/server/domain/folder/dto/FolderRequestDTO.java
+++ b/src/main/java/com/clokey/server/domain/folder/dto/FolderRequestDTO.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
 
 public class FolderRequestDTO {
@@ -12,6 +13,7 @@ public class FolderRequestDTO {
     public static class FolderCreateRequest {
         @NotBlank(message = "폴더 이름은 필수 입력 값입니다.")
         String folderName;
+        List<Long> clothIds = Collections.emptyList();
     }
 
     @Getter


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #129 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 폴더 생성 로직에 옷 추가 로직 추가
- 공통 로직 함수로 만들어서 사용하도록 리팩토링

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- Collections.emptyList()로 필드에 입력되지 않을 때에도 emptyList로 만들어서 Service에서 처리 가능하도록 하였습니다.
- 공통 로직을 함수를 만들었습니다.
- 폴더 생성에 clothIds를 받았을 때만 생성된 폴더에 옷 추가 로직을 추가하였습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
