### PR TITLE
[refactor/#128] 폼데이터 방식 변경

### DIFF
--- a/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
@@ -13,10 +13,13 @@ import com.clokey.server.global.common.response.BaseResponse;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Validated
 @RestController
@@ -27,16 +30,32 @@ public class MemberRestController {
     private final GetUserQueryService getUserQueryService;
     private final FollowCommandService followCommandService;
 
-    @Operation(summary = "프로필 수정 API", description = "사용자의 프로필 정보를 수정하는 API입니다.")
-    @PatchMapping("users/profile")
-    public BaseResponse<MemberDTO.ProfileRP> updateProfile(
-            @Parameter(name = "user",hidden = true) @AuthUser Member member,
-            @RequestBody @Valid MemberDTO.ProfileRQ request) {
+//    @Operation(summary = "프로필 수정 API", description = "사용자의 프로필 정보를 수정하는 API입니다.")
+//    @PatchMapping("users/profile")
+//    public BaseResponse<MemberDTO.ProfileRP> updateProfile(
+//            @Parameter(name = "user",hidden = true) @AuthUser Member member,
+//            @RequestBody @Valid MemberDTO.ProfileRQ request) {
+//
+//        MemberDTO.ProfileRP response = profileCommandService.updateProfile(member.getId(), request);
+//
+//        return BaseResponse.onSuccess(SuccessStatus.MEMBER_ACTION_SUCCESS, response);
+//    }
 
-        MemberDTO.ProfileRP response = profileCommandService.updateProfile(member.getId(), request);
+    @Operation(summary = "프로필 수정 API", description = "사용자의 프로필 정보를 수정하는 API입니다.")
+    @PatchMapping(value = "users/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<MemberDTO.ProfileRP> updateProfile(
+            @Parameter(name = "user", hidden = true) @AuthUser Member member,
+            @RequestPart("data") @Valid MemberDTO.ProfileRQ request,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+            @RequestPart(value = "profileBackImage", required = false) MultipartFile profileBackImage) {
+
+        MemberDTO.ProfileRP response = profileCommandService.updateProfile(member.getId(), request, profileImage, profileBackImage);
 
         return BaseResponse.onSuccess(SuccessStatus.MEMBER_ACTION_SUCCESS, response);
     }
+
+
+
 
     @Operation(summary = "아이디 중복 조회 API", description = "사용자의 클로키 아이디가 이미 사용 중인지 조회하는 API입니다.")
     @GetMapping("users/{clokey_id}/check")

--- a/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
@@ -45,7 +45,7 @@ public class MemberRestController {
     @PatchMapping(value = "users/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<MemberDTO.ProfileRP> updateProfile(
             @Parameter(name = "user", hidden = true) @AuthUser Member member,
-            @RequestPart("data") @Valid MemberDTO.ProfileRQ request,
+            @RequestPart("profileRequest") @Valid MemberDTO.ProfileRQ request,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
             @RequestPart(value = "profileBackImage", required = false) MultipartFile profileBackImage) {
 

--- a/src/main/java/com/clokey/server/domain/member/application/ProfileCommandService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/ProfileCommandService.java
@@ -2,8 +2,10 @@ package com.clokey.server.domain.member.application;
 
 
 import com.clokey.server.domain.member.dto.MemberDTO;
+import org.springframework.web.multipart.MultipartFile;
 
 
 public interface ProfileCommandService {
-    MemberDTO.ProfileRP updateProfile(Long userId, MemberDTO.ProfileRQ request);
+    MemberDTO.ProfileRP updateProfile(Long userId, MemberDTO.ProfileRQ request,
+                                      MultipartFile profileImage, MultipartFile profileBackImage);
 }

--- a/src/main/java/com/clokey/server/domain/member/application/ProfileCommandServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/ProfileCommandServiceImpl.java
@@ -4,26 +4,33 @@ import com.clokey.server.domain.member.converter.ProfileConverter;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.model.entity.enums.RegisterStatus;
 import com.clokey.server.domain.member.dto.MemberDTO;
+import com.clokey.server.global.infra.s3.S3ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class ProfileCommandServiceImpl implements ProfileCommandService {
 
     private final MemberRepositoryService memberRepositoryService;
+    private final S3ImageService s3ImageService; // ✅ S3 업로드 서비스 추가
 
     @Override
     @Transactional
-    public MemberDTO.ProfileRP updateProfile(Long userId, MemberDTO.ProfileRQ request) {
+    public MemberDTO.ProfileRP updateProfile(Long userId, MemberDTO.ProfileRQ request,
+                                             MultipartFile profileImage, MultipartFile profileBackImage) {
         // 사용자 확인
         Member member = memberRepositoryService.findMemberById(userId);
 
-        // 프로필 업데이트
-        member.profileUpdate(request);
+        // ✅ S3 업로드 후 URL 저장
+        String profileImageUrl = (profileImage != null && !profileImage.isEmpty()) ? s3ImageService.upload(profileImage) : member.getProfileImageUrl();
+        String profileBackImageUrl = (profileBackImage != null && !profileBackImage.isEmpty()) ? s3ImageService.upload(profileBackImage) : member.getProfileBackImageUrl();
 
-        if(member.getRegisterStatus()!=RegisterStatus.REGISTERED) {
+        member.profileUpdate(request, profileImageUrl, profileBackImageUrl);
+
+        if (member.getRegisterStatus() != RegisterStatus.REGISTERED) {
             // 약관 동의가 완료되었으므로 회원의 등록 상태를 업데이트
             member.updateRegisterStatus(RegisterStatus.REGISTERED);
         }

--- a/src/main/java/com/clokey/server/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/clokey/server/domain/member/domain/entity/Member.java
@@ -90,12 +90,12 @@ public class Member extends BaseEntity {
     private List<History> historyList = new ArrayList<>();
 
 
-    public void profileUpdate(MemberDTO.ProfileRQ request) {
+    public void profileUpdate(MemberDTO.ProfileRQ request, String profileImageUrl, String profileBackImageUrl) {
         this.nickname = request.getNickname();
         this.clokeyId = request.getClokeyId();
-        this.profileImageUrl = request.getProfileImageUrl();
+        this.profileImageUrl = profileImageUrl;
         this.bio = request.getBio();
-        this.profileBackImageUrl = request.getProfileBackImageUrl();
+        this.profileBackImageUrl = profileBackImageUrl;
         this.visibility = request.getVisibility();
     }
 

--- a/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
@@ -42,11 +42,7 @@ public class MemberDTO {
         @EssentialFieldNotNull
         String clokeyId;
 
-        String profileImageUrl;
-
         private String bio;
-
-        private String profileBackImageUrl;
 
         Visibility visibility;
 

--- a/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/clokey/server/global/config/security/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
             "/login",
             "/refresh",
             "/ws/**",
-            "/topic/**"
+            "/topic/**",
+            "/reissue-token"
     };
 
     @Bean


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #128 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 기존에 사진 url로 주고 받는 방식에서 s3로 변경이 안되어있어서 변경했습니다.
- reissue-token api가 미로그인시에도 사용 가능해야 한다고 생각하여 Config에 추가했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/16de5975-c3c9-4c82-a265-b1a0ecec4ba4)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
