### PR TITLE
[feat/#118] 스마트 요약 API 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/category/exception/CategoryException.java
+++ b/src/main/java/com/clokey/server/domain/category/exception/CategoryException.java
@@ -1,0 +1,9 @@
+package com.clokey.server.domain.category.exception;
+
+import com.clokey.server.global.error.code.BaseErrorCode;
+import com.clokey.server.global.error.exception.GeneralException;
+
+public class CategoryException extends GeneralException {
+
+    public CategoryException(BaseErrorCode code) {super(code);}
+}

--- a/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
+++ b/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
@@ -15,6 +15,7 @@ import com.clokey.server.domain.member.exception.annotation.IdValid;
 import com.clokey.server.domain.member.exception.validator.MemberAccessibleValidator;
 import com.clokey.server.domain.model.entity.enums.ClothSort;
 import com.clokey.server.domain.model.entity.enums.Season;
+import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
 import com.clokey.server.global.common.response.BaseResponse;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import com.clokey.server.global.error.exception.annotation.CheckPage;
@@ -40,7 +41,29 @@ public class ClothRestController {
     private final ClothAccessibleValidator clothAccessibleValidator;
     private final MemberAccessibleValidator memberAccessibleValidator;
 
-    // 옷장의 옷 조회 API, 사용자 토큰 받는 부분 추가 및 변경해야함
+    // 스마트 요약 API
+    @GetMapping("/smart-summary")
+    @Operation(summary = "일주일간 평균 착용 횟수에 따른 스마트 요약 API", description = "query string으로 SummaryFrequency를 넘겨주세요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_200", description = "OK, 성공적으로 조회되었습니다."),
+    })
+    @Parameters({
+            @Parameter(name = "type", description = "빈도수(SummaryFrequency) ENUM 값 { "+
+                    "//지난 7일간 자주 착용한 옷 FREQUENT,"+
+                    "//지난 7일간 자주 착용하지 않은 옷 INFREQUENT,"+
+                    "}, query string 입니다."),
+    })
+    public BaseResponse<ClothResponseDTO.SmartSummaryClothPreviewListResult> getClothPreviewInfoListByCategoryId(
+            @RequestParam SummaryFrequency type,
+            @Parameter(name = "user", hidden = true) @AuthUser Member member
+    ) {
+        // ClothService를 통해 데이터를 가져오고, 결과 반환
+        ClothResponseDTO.SmartSummaryClothPreviewListResult result = clothService.readSmartSummaryByFrequencyType(type, member.getId());
+
+        return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
+    }
+
+    // 옷장의 옷 조회 API
     @GetMapping("/{clokeyId}")
     @Operation(summary = "유저의 옷장을 조회하는 API", description = "path variable으로 clokeyId를 넘겨주세요" +
                                                                     "query string으로 category_id를 넘겨주세요." +
@@ -82,7 +105,7 @@ public class ClothRestController {
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }
 
-    // 팝업용 옷 조회 API, 사용자 토큰 받는 부분 추가 및 변경해야함
+    // 팝업용 옷 조회 API
     @GetMapping("/{clothId}/popup-view")
     @Operation(summary = "특정 옷을 팝업용으로 조회하는 API", description = "path variable로 cloth_id를 넘겨주세요.")
     @ApiResponses({
@@ -107,7 +130,7 @@ public class ClothRestController {
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }
 
-    // 수정용 옷 조회 API, 사용자 토큰 받는 부분 추가 및 변경해야함
+    // 수정용 옷 조회 API
     @GetMapping("/{clothId}/edit-view")
     @Operation(summary = "특정 옷을 수정용으로 조회하는 API", description = "path variable로 cloth_id를 넘겨주세요.")
     @ApiResponses({
@@ -132,7 +155,7 @@ public class ClothRestController {
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }
 
-    // 옷 상세 조회 API, 사용자 토큰 받는 부분 추가 및 변경해야함
+    // 옷 상세 조회 API
     @GetMapping("/{clothId}/detail-view")
     @Operation(summary = "특정 옷을 상세 조회하는 API", description = "path variable로 cloth_id를 넘겨주세요.")
     @ApiResponses({
@@ -157,7 +180,7 @@ public class ClothRestController {
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }
 
-    // 옷 생성 API, 사용자 토큰 받는 부분 추가 및 변경해야함
+    // 옷 생성 API
     @PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "새로운 옷을 생성하는 API", description = "query string으로 category_id를 넘겨주세요.\nrequest body에 ClothCreateRequestDTO 형식의 데이터를 전달해주세요.")
     @ApiResponses({
@@ -178,7 +201,7 @@ public class ClothRestController {
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_CREATED, result);
     }
 
-    // 옷 수정 API, 사용자 토큰 받는 부분 추가 및 변경해야함
+    // 옷 수정 API
     @PatchMapping(value = "/{clothId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "특정 옷을 수정하는 API", description = "path variable로 cloth_id를 넘겨주세요.\nquery string으로 category_id를 넘겨주세요.\nrequest body에 ClothCreateOrUpdateRequestDTO 형식의 데이터를 전달해주세요.")
     @ApiResponses({
@@ -204,7 +227,7 @@ public class ClothRestController {
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_EDITED, null);
     }
 
-    // 옷 삭제 API, 사용자 토큰 받는 부분 추가 및 변경해야함
+    // 옷 삭제 API
     @DeleteMapping("/{clothId}")
     @Operation(summary = "특정 옷을 삭제하는 API", description = "path variable로 cloth_id를 넘겨주세요.")
     @ApiResponses({

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothRepositoryService.java
@@ -3,6 +3,7 @@ package com.clokey.server.domain.cloth.application;
 import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.model.entity.enums.ClothSort;
 import com.clokey.server.domain.model.entity.enums.Season;
+import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
@@ -19,13 +20,19 @@ public interface ClothRepositoryService {
 
     boolean existsById(Long clothId);
 
-    Page<Cloth> findByFilters(
+    Page<Cloth> findByClosetFilters(
             @Param("clokeyId") String clokeyId,
             @Param("requesterId") Long requesterId,
             @Param("categoryId") Long categoryId,
             @Param("season") Season season,
             @Param("sort") ClothSort sort,
             Pageable pageable
+    );
+
+    List<Cloth> findBySmartSummaryFilters(
+            @Param("type") SummaryFrequency type,
+            @Param("memberId") Long memberId,
+            @Param("categoryId") Long categoryId
     );
 
     List<Cloth> findAllById(List<Long> clothIds);

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothRepositoryServiceImpl.java
@@ -4,6 +4,7 @@ import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.cloth.domain.repository.ClothRepository;
 import com.clokey.server.domain.model.entity.enums.ClothSort;
 import com.clokey.server.domain.model.entity.enums.Season;
+import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.exception.DatabaseException;
 import jakarta.transaction.Transactional;
@@ -16,7 +17,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -48,7 +48,7 @@ public class ClothRepositoryServiceImpl implements ClothRepositoryService{
     }
 
     @Override
-    public Page<Cloth> findByFilters(
+    public Page<Cloth> findByClosetFilters(
             @Param("ownerClokeyId") String ownerClokeyId,
             @Param("requesterId") Long requesterId,
             @Param("categoryId") Long categoryId,
@@ -56,7 +56,19 @@ public class ClothRepositoryServiceImpl implements ClothRepositoryService{
             @Param("sort") ClothSort sort,
             Pageable pageable
     ){
-        return clothRepository.findByFilters(ownerClokeyId, requesterId, categoryId, season, sort.toString(), pageable);
+        return clothRepository.findByClosetFilters(ownerClokeyId, requesterId, categoryId, season, sort.toString(), pageable);
+    }
+
+    @Override
+    public List<Cloth> findBySmartSummaryFilters(
+            @Param("type") SummaryFrequency type,
+            @Param("memberId") Long memberId,
+            @Param("categoryId") Long categoryId
+    ){
+        return switch (type) {
+            case FREQUENT -> clothRepository.findMostFrequentClothList(memberId,categoryId);
+            case INFREQUENT -> clothRepository.findLeastFrequentClothList(memberId,categoryId);
+        };
     }
   
     public List<Cloth> findAllById(List<Long> clothIds) {

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
@@ -4,6 +4,7 @@ import com.clokey.server.domain.cloth.dto.ClothRequestDTO;
 import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 import com.clokey.server.domain.model.entity.enums.ClothSort;
 import com.clokey.server.domain.model.entity.enums.Season;
+import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ClothService {
@@ -15,6 +16,8 @@ public interface ClothService {
     ClothResponseDTO.ClothDetailViewResult readClothDetailInfoById(Long clothId);
 
     ClothResponseDTO.CategoryClothPreviewListResult readClothPreviewInfoListByClokeyId(String ownerClokeyId, Long requesterId, Long categoryId, Season season, ClothSort sort, int page, int pageSize);
+
+    ClothResponseDTO.SmartSummaryClothPreviewListResult readSmartSummaryByFrequencyType(SummaryFrequency frequencyType, Long memberId);
 
     ClothResponseDTO.ClothCreateResult createCloth(Long categoryId, Long memberId, ClothRequestDTO.ClothCreateOrUpdateRequest request, MultipartFile imageFile);
 

--- a/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
+++ b/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
@@ -5,6 +5,7 @@ import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 import com.clokey.server.domain.category.domain.entity.Category;
 import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.member.domain.entity.Member;
+import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
 import org.springframework.data.domain.Page;
 
 import java.time.format.TextStyle;
@@ -95,15 +96,41 @@ public class ClothConverter {
                 ).collect(Collectors.toList());
     }
 
-    public static ClothResponseDTO.CategoryClothPreviewListResult toClothPreviewListResult(Page<Cloth> clothes,
-                                                                                           List<ClothResponseDTO.ClothPreview> clothPreviews){
+    public static List<ClothResponseDTO.ClothPreview> toClothPreviewList(List<Cloth> clothes) {
+        return clothes.stream()
+                .map(cloth -> ClothResponseDTO.ClothPreview.builder()
+                        .id(cloth.getId())
+                        .name(cloth.getName())
+                        .imageUrl(cloth.getImage() != null ? cloth.getImage().getImageUrl() : null)
+                        .wearNum(cloth.getWearNum())
+                        .build()
+                ).collect(Collectors.toList());
+    }
+
+    public static ClothResponseDTO.CategoryClothPreviewListResult toClosetClothPreviewListResult(Page<Cloth> clothes,
+                                                                                                 List<ClothResponseDTO.ClothPreview> clothPreviews){
         return ClothResponseDTO.CategoryClothPreviewListResult.builder()
-                .clothes(clothPreviews)
-                .listSize(clothPreviews.size())
+                .clothPreviews(clothPreviews)
                 .totalPage(clothes.getTotalPages())
                 .totalElements(clothes.getTotalElements())
                 .isFirst(clothes.isFirst())
                 .isLast(clothes.isLast())
+                .build();
+    }
+
+    public static ClothResponseDTO.SmartSummaryClothPreviewListResult toSummaryClothPreviewListResult(
+            SummaryFrequency frequencyType,
+            Category category,
+            Double averageUsage,
+            List<ClothResponseDTO.ClothPreview> clothPreviews
+    ) {
+        return ClothResponseDTO.SmartSummaryClothPreviewListResult.builder()
+                .type(frequencyType)
+                .baseCategoryName(category.getParent().getName())
+                .coreCategoryName(category.getName())
+                .coreCategoryId(category.getId())
+                .averageUsage(averageUsage)
+                .clothPreviews(clothPreviews)
                 .build();
     }
 

--- a/src/main/java/com/clokey/server/domain/cloth/domain/repository/ClothRepository.java
+++ b/src/main/java/com/clokey/server/domain/cloth/domain/repository/ClothRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ClothRepository extends JpaRepository<Cloth, Long> {
@@ -37,7 +38,7 @@ public interface ClothRepository extends JpaRepository<Cloth, Long> {
             "CASE WHEN :sort = 'OLDEST' THEN c.createdAt END ASC, " +
             "CASE WHEN :sort = 'LATEST' THEN c.createdAt END DESC"
     )
-    Page<Cloth> findByFilters(
+    Page<Cloth> findByClosetFilters(
             @Param("clokeyId") String clokeyId,
             @Param("memberId") Long memberId,
             @Param("categoryId") Long categoryId,
@@ -45,4 +46,18 @@ public interface ClothRepository extends JpaRepository<Cloth, Long> {
             @Param("sort") String sort,
             Pageable pageable
     );
+
+
+    @Query("SELECT c FROM Cloth c " +
+            "WHERE c.member.id = :memberId " +
+            "AND c.category.id = :categoryId " +
+            "ORDER BY c.wearNum ASC, c.id ASC LIMIT 3")
+    List<Cloth> findLeastFrequentClothList(@Param("memberId") Long memberId, @Param("categoryId") Long categoryId);
+
+
+    @Query("SELECT c FROM Cloth c " +
+            "WHERE c.member.id = :memberId " +
+            "AND c.category.id = :categoryId " +
+            "ORDER BY c.wearNum DESC, c.id ASC LIMIT 3")
+    List<Cloth> findMostFrequentClothList(@Param("memberId") Long memberId, @Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
@@ -1,6 +1,7 @@
 package com.clokey.server.domain.cloth.dto;
 
 import com.clokey.server.domain.model.entity.enums.Season;
+import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
 import com.clokey.server.domain.model.entity.enums.ThicknessLevel;
 import com.clokey.server.domain.model.entity.enums.Visibility;
 import lombok.*;
@@ -93,12 +94,23 @@ public class ClothResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CategoryClothPreviewListResult {
-        private List<ClothPreview> clothes;
-        private int listSize;
+        private List<ClothPreview> clothPreviews;
         private int totalPage;
         private long totalElements;
         private boolean isFirst;
         private boolean isLast;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SmartSummaryClothPreviewListResult {
+        private SummaryFrequency type;
+        private String baseCategoryName;
+        private String coreCategoryName;
+        private Long coreCategoryId;
+        private Double averageUsage;
+        private List<ClothPreview> clothPreviews;
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -1,7 +1,6 @@
 package com.clokey.server.domain.history.application;
 
 import com.clokey.server.domain.history.domain.entity.History;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -9,6 +8,8 @@ import java.util.List;
 public interface HistoryRepositoryService {
 
     List<History> findHistoriesByMemberAndYearMonth(Long memberId, String yearMonth);
+
+    List<History> findHistoriesByMemberWithinWeek(Long memberId);
 
     void incrementLikes(Long historyId);
 

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
@@ -20,6 +20,11 @@ public class HistoryRepositoryServiceImpl implements HistoryRepositoryService {
         return historyRepository.findHistoriesByMemberAndYearMonth(memberId,yearMonth);
     }
 
+    @Override
+    public List<History> findHistoriesByMemberWithinWeek(Long memberId){
+        LocalDate weekAgo = LocalDate.now().minusWeeks(1);
+        return historyRepository.findHistoriesWithinWeek(memberId,weekAgo);
+    }
 
     @Override
     public void incrementLikes(Long historyId){

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -15,6 +15,9 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("SELECT h FROM History h WHERE h.member.id = :memberId AND FUNCTION('DATE_FORMAT', h.historyDate, '%Y-%m') = :yearMonth")
     List<History> findHistoriesByMemberAndYearMonth(Long memberId, String yearMonth);
 
+    @Query("SELECT h FROM History h WHERE h.member.id = :memberId AND h.historyDate >= :weekAgo")
+    List<History> findHistoriesWithinWeek(@Param("memberId") Long memberId, @Param("weekAgo") LocalDate weekAgo);
+
     @Query("UPDATE History h SET h.likes = h.likes + 1 WHERE h.id = :historyId")
     void incrementLikes(Long historyId);
 

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -41,6 +41,8 @@ public enum ErrorStatus implements BaseErrorCode {
     CLOTH_INVAID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST,"CLOTH_4009","옷의 사진을 입력하지 않았습니다."),
     NO_CLOTH_IMAGE_INPUT(HttpStatus.BAD_REQUEST,"CLOTH_4010","옷의 사진 형식이 올바르지 않습니다."),
     INVALID_CREATE_OR_UPDATE_CLOTH_FORMAT(HttpStatus.BAD_REQUEST,"CLOTH_4011","옷의 생성 및 수정 형식이 올바르지 않습니다."),
+    CLOTH_NOT_FOUND_IN_SUMMARY(HttpStatus.NOT_FOUND,"CLOTH_4012","스마트 요약에서 옷을 찾지 못했습니다."),
+
 
     //폴더 에러
     NO_SUCH_FOLDER(HttpStatus.NOT_FOUND,"FOLDER_4041","존재하지 않는 폴더 ID입니다."),
@@ -53,6 +55,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //카테고리 에러
     NO_SUCH_CATEGORY(HttpStatus.NOT_FOUND,"CATEGORY_4041","존재하지 않는 카테고리 ID입니다."),
+    CATEGORY_NOT_FOUND_IN_SUMMARY(HttpStatus.NOT_FOUND,"CATEGORY_4001","스마트 요약에서 카테고리를 찾지 못했습니다."),
 
     //기록 에러
     DATE_INVALID(HttpStatus.BAD_REQUEST,"HISTORY_4001","잘못된 날짜 형식입니다."),

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -42,7 +42,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NO_CLOTH_IMAGE_INPUT(HttpStatus.BAD_REQUEST,"CLOTH_4010","옷의 사진 형식이 올바르지 않습니다."),
     INVALID_CREATE_OR_UPDATE_CLOTH_FORMAT(HttpStatus.BAD_REQUEST,"CLOTH_4011","옷의 생성 및 수정 형식이 올바르지 않습니다."),
     CLOTH_NOT_FOUND_IN_SUMMARY(HttpStatus.NOT_FOUND,"CLOTH_4012","스마트 요약에서 옷을 찾지 못했습니다."),
-
+    INVALID_SUMMARY_FREQUENCY_TYPE(HttpStatus.BAD_REQUEST,"CLOTH_4013","스마트 요약에서 빈도수를 잘못 입력했습니다."),
 
     //폴더 에러
     NO_SUCH_FOLDER(HttpStatus.NOT_FOUND,"FOLDER_4041","존재하지 않는 폴더 ID입니다."),


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #118 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
스마트요약 API를 작업했습니다. 카테고리 레포지토리를 사용해서 만들었다가 로직이 이상해서.. 전부 기록 레포지토리로 다시 만들었습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- History Repository/RepositoryService로 지난 일주일간 기록을 가져오는 메소드를 작성했습니다.
- ClothService에서 지난 일주일 기록에 태그된 옷 리스트를 HistoryCloth RepositoryService를 통해서 가져오는 메소드를 작성했습니다.
- Frequency Type에 따라서 옷 리스트의 카테고리와 착용횟수를 구하는 메소드를 작성했습니다.
- 위를 통해 스마트 요약 API를 구현하였습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/294e1ebd-cc3a-46de-8909-40b3387e2770)

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
최대 최소 착용 로직이 잘 되어있는지 봐주시면 감사하겠습니다!
