### PR TITLE
[fix/#138] history가 기록될 경우 wearnum이 올라가지 않던 오류 해결

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryClothRepositoryServiceImpl.java
@@ -4,12 +4,8 @@ import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.domain.entity.HistoryCloth;
 import com.clokey.server.domain.history.domain.repository.HistoryClothRepository;
-import com.clokey.server.domain.history.domain.repository.HistoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -213,6 +213,7 @@ public class HistoryServiceImpl implements HistoryService {
         List<Cloth> cloths = clothRepositoryService.findAllById(historyCreateRequest.getClothes());
         List<HistoryCloth> historyCloths = cloths.stream()
                         .map(cloth -> {
+                            cloth.increaseWearNum();
                             return HistoryCloth.builder()
                                     .history(history)
                                     .cloth(cloth)


### PR DESCRIPTION
## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #138 

## 🌱 PR 요약
history가 기록될 경우 wearnum이 올라가지 않던 오류 해결

## 🛠 작업 내용
- 기록을 post하는 API를 수정했습니다.
- 삭제나 업데이트는 문제가 없는 것을 확인했습니다.
- 기존의 DB에서 기록되었던 옷의 wear_num을 수동으로 올려주었습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
