### PR TITLE
[feat/#133] 사용자의 모든 폴더 조회 api 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/folder/api/FolderRestController.java
+++ b/src/main/java/com/clokey/server/domain/folder/api/FolderRestController.java
@@ -29,9 +29,9 @@ public class FolderRestController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FOLDER_201", description = "성공적으로 생성되었습니다."),
     })
-    public BaseResponse<FolderResponseDTO.FolderId> createFolder(@Parameter(name = "user",hidden = true) @AuthUser Member member,
+    public BaseResponse<FolderResponseDTO.FolderIdResult> createFolder(@Parameter(name = "user",hidden = true) @AuthUser Member member,
                                                                  @RequestBody @Valid FolderRequestDTO.FolderCreateRequest request) {
-        FolderResponseDTO.FolderId response = FolderConverter.toFolderIdDTO(folderService.createFolder(member.getId(), request));
+        FolderResponseDTO.FolderIdResult response = FolderConverter.toFolderIdDTO(folderService.createFolder(member.getId(), request));
         return BaseResponse.onSuccess(SuccessStatus.FOLDER_CREATED, response);
     }
 
@@ -86,10 +86,21 @@ public class FolderRestController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FOLDER_200", description = "성공적으로 조회되었습니다."),
     })
-    public BaseResponse<FolderResponseDTO.FolderClothes> getClothesFromFolder(@Parameter(name = "user",hidden = true) @AuthUser Member member,
+    public BaseResponse<FolderResponseDTO.FolderClothesResult> getClothesFromFolder(@Parameter(name = "user",hidden = true) @AuthUser Member member,
                                                         @PathVariable @FolderExist Long folderId,
                                                                                  @RequestParam(value = "page") @Valid @CheckPage Integer page) {
-        FolderResponseDTO.FolderClothes result = folderService.getClothesFromFolder(folderId, page, member.getId());
+        FolderResponseDTO.FolderClothesResult result = folderService.getClothesFromFolder(folderId, page, member.getId());
+        return BaseResponse.onSuccess(SuccessStatus.FOLDER_SUCCESS, result);
+    }
+
+    @Operation(summary = "전체 폴더 조회 API", description = "사용자가 가지고 있는 전체 폴더를 조회하는 API입니다.")
+    @GetMapping("folders")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FOLDER_200", description = "성공적으로 조회되었습니다."),
+    })
+    public BaseResponse<FolderResponseDTO.FoldersResult> getFolders(@Parameter(name = "user",hidden = true) @AuthUser Member member,
+                                                                              @RequestParam(value = "page") @Valid @CheckPage Integer page) {
+        FolderResponseDTO.FoldersResult result = folderService.getFolders(page, member.getId());
         return BaseResponse.onSuccess(SuccessStatus.FOLDER_SUCCESS, result);
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryService.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ClothFolderRepositoryService {
 
@@ -25,4 +26,8 @@ public interface ClothFolderRepositoryService {
     void validateNoDuplicateClothes(List<Cloth> clothes, Long folderId);
 
     Page<ClothFolder> findAllByFolderId(Long folderId, Pageable page);
+
+    Map<Long, String> findClothImageUrlsFromFolderIds(List<Long> folderIds);
+
+    Map<Long, Long> countClothesByFolderIds(List<Long> folderIds);
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryService.java
@@ -30,4 +30,6 @@ public interface ClothFolderRepositoryService {
     Map<Long, String> findClothImageUrlsFromFolderIds(List<Long> folderIds);
 
     Map<Long, Long> countClothesByFolderIds(List<Long> folderIds);
+
+    void deleteAllByFolderId(@Param("folderId") Long folderId);
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -65,5 +66,19 @@ public class ClothFolderRepositoryServiceImpl implements ClothFolderRepositorySe
     @Override
     public Page<ClothFolder> findAllByFolderId(Long folderId, Pageable page) {
         return clothFolderRepository.findAllByFolderId(folderId, page);
+    }
+
+    @Override
+    public Map<Long, String> findClothImageUrlsFromFolderIds(List<Long> folderIds) {
+        List<Object[]> results = clothFolderRepository.findClothImageUrlsFromFolderIds(folderIds);
+        return results.stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (String) row[1]));
+    }
+
+    @Override
+    public Map<Long, Long> countClothesByFolderIds(List<Long> folderIds) {
+        List<Object[]> results = clothFolderRepository.countClothesByFolderIds(folderIds);
+        return results.stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryServiceImpl.java
@@ -25,6 +25,7 @@ public class ClothFolderRepositoryServiceImpl implements ClothFolderRepositorySe
     private final ClothFolderRepository clothFolderRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public boolean existsByClothIdAndFolderId(Long clothId, Long folderId){
         return clothFolderRepository.existsByClothIdAndFolderId(clothId,folderId);
     }
@@ -43,6 +44,7 @@ public class ClothFolderRepositoryServiceImpl implements ClothFolderRepositorySe
 
 
     @Override
+    @Transactional(readOnly = true)
     public List<ClothFolder> findAllByClothIdsAndFolderId(List<Long> clothIds, Long folderId) {
         return clothFolderRepository.findByClothIdInAndFolderId(clothIds, folderId);
     }
@@ -54,6 +56,7 @@ public class ClothFolderRepositoryServiceImpl implements ClothFolderRepositorySe
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void validateNoDuplicateClothes(List<Cloth> clothes, Long folderId) {
         List<Long> clothIds = clothes.stream().map(Cloth::getId).collect(Collectors.toList());
         List<ClothFolder> existingClothIds = clothFolderRepository.findByClothIdInAndFolderId(clothIds, folderId);
@@ -64,11 +67,13 @@ public class ClothFolderRepositoryServiceImpl implements ClothFolderRepositorySe
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<ClothFolder> findAllByFolderId(Long folderId, Pageable page) {
         return clothFolderRepository.findAllByFolderId(folderId, page);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, String> findClothImageUrlsFromFolderIds(List<Long> folderIds) {
         List<Object[]> results = clothFolderRepository.findClothImageUrlsFromFolderIds(folderIds);
         return results.stream()
@@ -76,6 +81,7 @@ public class ClothFolderRepositoryServiceImpl implements ClothFolderRepositorySe
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Map<Long, Long> countClothesByFolderIds(List<Long> folderIds) {
         List<Object[]> results = clothFolderRepository.countClothesByFolderIds(folderIds);
         return results.stream()

--- a/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/ClothFolderRepositoryServiceImpl.java
@@ -87,4 +87,10 @@ public class ClothFolderRepositoryServiceImpl implements ClothFolderRepositorySe
         return results.stream()
                 .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
     }
+
+    @Modifying
+    @Transactional
+    public void deleteAllByFolderId(@Param("folderId") Long folderId){
+        clothFolderRepository.deleteAllByFolderId(folderId);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryService.java
@@ -1,6 +1,8 @@
 package com.clokey.server.domain.folder.application;
 
 import com.clokey.server.domain.folder.domain.entity.Folder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface FolderRepositoryService {
 
@@ -11,5 +13,7 @@ public interface FolderRepositoryService {
     Folder findById(Long folderId);
 
     boolean existsById(Long folderId);
+
+    Page<Folder> findAllByMemberId(Long memberId, Pageable page);
 
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
@@ -10,19 +10,19 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@Transactional
 @Service
 @RequiredArgsConstructor
 public class FolderRepositoryServiceImpl implements FolderRepositoryService{
 
     private final FolderRepository folderRepository;
 
-
+    @Transactional
     @Override
     public void save(Folder folderId) {
         folderRepository.save(folderId);
     }
 
+    @Transactional
     @Override
     public void deleteById(Long folderId) {
         folderRepository.deleteById(folderId);
@@ -35,11 +35,13 @@ public class FolderRepositoryServiceImpl implements FolderRepositoryService{
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean existsById(Long folderId) {
         return folderRepository.existsById(folderId);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<Folder> findAllByMemberId(Long memberId, Pageable page) {
         return folderRepository.findAllByMemberId(memberId, page);
     }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderRepositoryServiceImpl.java
@@ -4,6 +4,8 @@ import com.clokey.server.domain.folder.domain.entity.Folder;
 import com.clokey.server.domain.folder.domain.repository.FolderRepository;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.exception.DatabaseException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,5 +37,10 @@ public class FolderRepositoryServiceImpl implements FolderRepositoryService{
     @Override
     public boolean existsById(Long folderId) {
         return folderRepository.existsById(folderId);
+    }
+
+    @Override
+    public Page<Folder> findAllByMemberId(Long memberId, Pageable page) {
+        return folderRepository.findAllByMemberId(memberId, page);
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/application/FolderService.java
+++ b/src/main/java/com/clokey/server/domain/folder/application/FolderService.java
@@ -10,5 +10,6 @@ public interface FolderService {
     void editFolderName(Long folderId, String newName, Long memberId);
     void addClothesToFolder(Long folderId, FolderRequestDTO.UpdateClothesInFolderRequest request, Long memberId);
     void deleteClothesFromFolder(Long folderId, FolderRequestDTO.UpdateClothesInFolderRequest request, Long memberId);
-    FolderResponseDTO.FolderClothes getClothesFromFolder(Long folderId, Integer page, Long memberId);
+    FolderResponseDTO.FolderClothesResult getClothesFromFolder(Long folderId, Integer page, Long memberId);
+    FolderResponseDTO.FoldersResult getFolders(Integer page, Long memberId);
 }

--- a/src/main/java/com/clokey/server/domain/folder/converter/FolderConverter.java
+++ b/src/main/java/com/clokey/server/domain/folder/converter/FolderConverter.java
@@ -8,6 +8,7 @@ import com.clokey.server.domain.member.domain.entity.Member;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -19,15 +20,15 @@ public class FolderConverter {
                 .build();
     }
 
-    public static FolderResponseDTO.FolderId toFolderIdDTO(Folder folder) {
-        return FolderResponseDTO.FolderId.builder()
+    public static FolderResponseDTO.FolderIdResult toFolderIdDTO(Folder folder) {
+        return FolderResponseDTO.FolderIdResult.builder()
                 .folderId(folder.getId())
                 .build();
     }
 
-    public static FolderResponseDTO.FolderClothes toFolderClothesDTO(Page<ClothFolder> clothPage) {
-        List<FolderResponseDTO.FolderCloth> clothes = clothPage.getContent().stream()
-                .map(clothFolder -> new FolderResponseDTO.FolderCloth(
+    public static FolderResponseDTO.FolderClothesResult toFolderClothesDTO(Page<ClothFolder> clothPage) {
+        List<FolderResponseDTO.FolderClothResult> clothes = clothPage.getContent().stream()
+                .map(clothFolder -> new FolderResponseDTO.FolderClothResult(
                         clothFolder.getCloth().getId(),
                         clothFolder.getCloth().getName(),
                         clothFolder.getCloth().getImage().getImageUrl(),
@@ -35,12 +36,31 @@ public class FolderConverter {
                 ))
                 .collect(Collectors.toList());
 
-        return FolderResponseDTO.FolderClothes.builder()
+        return FolderResponseDTO.FolderClothesResult.builder()
                 .clothes(clothes)
                 .totalPage(clothPage.getTotalPages())
                 .totalElements((int) clothPage.getTotalElements())
                 .isFirst(clothPage.isFirst())
                 .isLast(clothPage.isLast())
+                .build();
+    }
+
+    public static FolderResponseDTO.FoldersResult toFoldersDTO(Page<Folder> folderPage, Map<Long, String> folderImageMap, Map<Long, Long> itemCountMap) {
+        List<FolderResponseDTO.FolderResult> folders = folderPage.getContent().stream()
+                .map(folder -> new FolderResponseDTO.FolderResult(
+                        folder.getId(),
+                        folder.getName(),
+                        folderImageMap.getOrDefault(folder.getId(), null),
+                        itemCountMap.getOrDefault(folder.getId(), 0L)
+                ))
+                .collect(Collectors.toList());
+
+        return FolderResponseDTO.FoldersResult.builder()
+                .folders(folders)
+                .totalPage(folderPage.getTotalPages())
+                .totalElements((int) folderPage.getTotalElements())
+                .isFirst(folderPage.isFirst())
+                .isLast(folderPage.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/converter/FolderConverter.java
+++ b/src/main/java/com/clokey/server/domain/folder/converter/FolderConverter.java
@@ -17,6 +17,7 @@ public class FolderConverter {
         return Folder.builder()
                 .name(request.getFolderName())
                 .member(member)
+                .itemCount(0L)
                 .build();
     }
 
@@ -45,13 +46,13 @@ public class FolderConverter {
                 .build();
     }
 
-    public static FolderResponseDTO.FoldersResult toFoldersDTO(Page<Folder> folderPage, Map<Long, String> folderImageMap, Map<Long, Long> itemCountMap) {
+    public static FolderResponseDTO.FoldersResult toFoldersDTO(Page<Folder> folderPage, Map<Long, String> folderImageMap) {
         List<FolderResponseDTO.FolderResult> folders = folderPage.getContent().stream()
                 .map(folder -> new FolderResponseDTO.FolderResult(
                         folder.getId(),
                         folder.getName(),
                         folderImageMap.getOrDefault(folder.getId(), null),
-                        itemCountMap.getOrDefault(folder.getId(), 0L)
+                        folder.getItemCount()
                 ))
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/clokey/server/domain/folder/domain/entity/Folder.java
+++ b/src/main/java/com/clokey/server/domain/folder/domain/entity/Folder.java
@@ -23,7 +23,16 @@ public class Folder extends BaseEntity {
     @Column(nullable = false, length = 30)
     private String name;
 
+    @Column(nullable = false, columnDefinition = "integer default 0")
+    private Long itemCount = 0L;
+
     public void rename(String newName) {
         this.name = newName;
+    }
+    public void increaseItemCount() {
+        this.itemCount++;
+    }
+    public void decreaseItemCount() {
+        this.itemCount--;
     }
 }

--- a/src/main/java/com/clokey/server/domain/folder/domain/repository/ClothFolderRepository.java
+++ b/src/main/java/com/clokey/server/domain/folder/domain/repository/ClothFolderRepository.java
@@ -32,4 +32,9 @@ public interface ClothFolderRepository extends JpaRepository<ClothFolder, Long> 
 
     @Query("SELECT cf.folder.id, COUNT(cf) FROM ClothFolder cf WHERE cf.folder.id IN :folderIds GROUP BY cf.folder.id")
     List<Object[]> countClothesByFolderIds(@Param("folderIds") List<Long> folderIds);
+
+    @Transactional
+    @Modifying
+    void deleteAllByFolderId(@Param("folderId") Long folderId);
+
 }

--- a/src/main/java/com/clokey/server/domain/folder/domain/repository/ClothFolderRepository.java
+++ b/src/main/java/com/clokey/server/domain/folder/domain/repository/ClothFolderRepository.java
@@ -6,9 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ClothFolderRepository extends JpaRepository<ClothFolder, Long> {
 
@@ -24,4 +26,10 @@ public interface ClothFolderRepository extends JpaRepository<ClothFolder, Long> 
     void deleteAllByClothIdIn(List<Long> clothId);
 
     Page<ClothFolder> findAllByFolderId(Long folderId, Pageable page);
+
+    @Query("SELECT cf.folder.id, c.image.imageUrl FROM ClothFolder cf JOIN cf.cloth c WHERE cf.folder.id IN :folderIds GROUP BY cf.folder.id")
+    List<Object[]> findClothImageUrlsFromFolderIds(@Param("folderIds") List<Long> folderIds);
+
+    @Query("SELECT cf.folder.id, COUNT(cf) FROM ClothFolder cf WHERE cf.folder.id IN :folderIds GROUP BY cf.folder.id")
+    List<Object[]> countClothesByFolderIds(@Param("folderIds") List<Long> folderIds);
 }

--- a/src/main/java/com/clokey/server/domain/folder/domain/repository/FolderRepository.java
+++ b/src/main/java/com/clokey/server/domain/folder/domain/repository/FolderRepository.java
@@ -1,8 +1,10 @@
 package com.clokey.server.domain.folder.domain.repository;
 
 import com.clokey.server.domain.folder.domain.entity.Folder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
-
+    Page<Folder> findAllByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/clokey/server/domain/folder/dto/FolderResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/folder/dto/FolderResponseDTO.java
@@ -12,7 +12,7 @@ public class FolderResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class FolderId {
+    public static class FolderIdResult {
         private Long folderId;
     }
 
@@ -20,8 +20,8 @@ public class FolderResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class FolderClothes {
-        private List<FolderCloth> clothes;
+    public static class FolderClothesResult {
+        private List<FolderClothResult> clothes;
         private Integer totalPage;
         private Integer totalElements;
         private Boolean isFirst;
@@ -30,10 +30,31 @@ public class FolderResponseDTO {
 
     @Getter
     @AllArgsConstructor
-    public static class FolderCloth {
+    public static class FolderClothResult {
         private Long clothId;
         private String clothName;
         private String imageUrl;
         private Integer clothCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FoldersResult {
+        private List<FolderResult> folders;
+        private Integer totalPage;
+        private Integer totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class FolderResult {
+        private Long folderId;
+        private String folderName;
+        private String imageUrl;
+        private Long itemCount;
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #133 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 전체 폴더 가져오는 api 구현하였습니다

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 페이징 처리 되어있습니다.
- 폴더에 옷이 있다면 옷의 이미지url을 가져와서 각각 폴더마다 이미지 url을 반환하고, 옷이 없다면 null을 반환합니다.
- 폴더에 있는 아이템의 개수도 반환합니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/7d277ca3-cab3-4de1-bc47-2e38484997b6)

![image](https://github.com/user-attachments/assets/2282f26b-6728-49a5-82fd-b91a5e7f68ee)

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
ResponseDTO명 Result 붙여주세요~!