### PR TITLE
[fix/#156] 기록 좋아요 api, 기록 조회 api 수정

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryService.java
@@ -23,4 +23,5 @@ public interface CommentRepositoryService {
     void deleteById(Long commentId);
 
     void deleteAllComments(Long HistoryId);
+    Long countByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/CommentRepositoryServiceImpl.java
@@ -61,4 +61,9 @@ public class CommentRepositoryServiceImpl implements CommentRepositoryService{
         commentRepository.deleteParentCommentsByHistoryId(historyId);
     }
 
+    @Override
+    public Long countByHistoryId(Long historyId) {
+        return commentRepository.countByHistoryId(historyId);
+    }
+
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -125,8 +125,9 @@ public class HistoryServiceImpl implements HistoryService {
         int likeCount = memberLikeRepositoryService.countByHistory_Id(historyId);
         boolean isLiked = memberLikeRepositoryService.existsByMember_IdAndHistory_Id(memberId, historyId);
         List<Cloth> cloths = historyClothRepositoryService.findAllClothByHistoryId(historyId);
+        Long commentCount = commentRepositoryService.countByHistoryId(historyId);
 
-        return HistoryConverter.toDayViewResult(history, imageUrl, hashtags, likeCount, isLiked,cloths);
+        return HistoryConverter.toDayViewResult(history, imageUrl, hashtags, likeCount, isLiked, cloths, commentCount);
     }
 
     @Override

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -57,21 +57,20 @@ public class HistoryServiceImpl implements HistoryService {
 
         historyLikedValidator.validateIsLiked(historyId, memberId, isLiked);
 
-        History history = historyRepositoryService.findById(historyId);
-
         if (isLiked) {
             historyRepositoryService.decrementLikes(historyId);
             memberLikeRepositoryService.deleteByMember_IdAndHistory_Id(memberId, historyId);
         } else {
             historyRepositoryService.incrementLikes(historyId);
             MemberLike memberLike = MemberLike.builder()
-                    .history(history)
+                    .history(historyRepositoryService.findById(historyId))
                     .member(memberRepositoryService.findMemberById(memberId))
                     .build();
             memberLikeRepositoryService.save(memberLike);
         }
+        History updatedHistory = historyRepositoryService.findById(historyId);
 
-        return HistoryConverter.toLikeResult(history, isLiked);
+        return HistoryConverter.toLikeResult(updatedHistory, isLiked);
     }
 
     @Override

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -17,7 +17,7 @@ import java.util.stream.IntStream;
 
 public class HistoryConverter {
 
-    public static HistoryResponseDTO.DailyHistoryResult toDayViewResult(History history, List<String> imageUrl, List<String> hashtags, int likeCount, boolean isLiked, List<Cloth> cloths) {
+    public static HistoryResponseDTO.DailyHistoryResult toDayViewResult(History history, List<String> imageUrl, List<String> hashtags, int likeCount, boolean isLiked, List<Cloth> cloths, Long commentCount) {
         return HistoryResponseDTO.DailyHistoryResult.builder()
                 .memberId(history.getMember().getId())
                 .historyId(history.getId())
@@ -27,6 +27,7 @@ public class HistoryConverter {
                 .hashtags(hashtags)
                 .visibility(history.getVisibility().equals(Visibility.PUBLIC))
                 .likeCount(likeCount)
+                .commentCount(commentCount)
                 .isLiked(isLiked)
                 .date(history.getHistoryDate())
                 .nickName(history.getMember().getNickname())

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/CommentRepository.java
@@ -1,13 +1,13 @@
 package com.clokey.server.domain.history.domain.repository;
 
 import com.clokey.server.domain.history.domain.entity.Comment;
-import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -35,4 +35,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("DELETE FROM Comment c WHERE c.history.id = :historyId")
     void deleteParentCommentsByHistoryId(@Param("historyId") Long historyId);
 
+    @Transactional(readOnly = true)
+    Long countByHistoryId(Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -17,11 +17,11 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     List<History> findHistoriesByMemberAndYearMonth(Long memberId, String yearMonth);
 
     @Query("UPDATE History h SET h.likes = h.likes + 1 WHERE h.id = :historyId")
-    @Modifying
+    @Modifying(clearAutomatically = true)
     void incrementLikes(Long historyId);
 
     @Query("UPDATE History h SET h.likes = h.likes - 1 WHERE h.id = :historyId")
-    @Modifying
+    @Modifying(clearAutomatically = true)
     void decrementLikes(Long historyId);
 
     boolean existsByHistoryDateAndMember_Id(LocalDate historyDate, Long memberId);

--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDTO.java
@@ -31,6 +31,7 @@ public class HistoryResponseDTO {
         boolean isLiked;
         LocalDate date;
         List<HistoryClothResult> cloths;
+        Long commentCount;
     }
 
     @Builder


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #156 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 기록 좋아요 api 영속성 컨텍스트로 인해 likeCount 바로 반영 안되는 오류 수정
- 기록 일별 조회 api commentCount도 반환하도록 수정

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/31be0fe7-b620-462a-821b-2eb46bc43dda)

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
