### PR TITLE
[refactor/#160] 스마트 요약 API 리팩토링

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
+++ b/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
@@ -15,7 +15,6 @@ import com.clokey.server.domain.member.exception.annotation.IdValid;
 import com.clokey.server.domain.member.exception.validator.MemberAccessibleValidator;
 import com.clokey.server.domain.model.entity.enums.ClothSort;
 import com.clokey.server.domain.model.entity.enums.Season;
-import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
 import com.clokey.server.global.common.response.BaseResponse;
 import com.clokey.server.global.error.code.status.SuccessStatus;
 import com.clokey.server.global.error.exception.annotation.CheckPage;
@@ -47,18 +46,11 @@ public class ClothRestController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_200", description = "OK, 성공적으로 조회되었습니다."),
     })
-    @Parameters({
-            @Parameter(name = "type", description = "빈도수(SummaryFrequency) ENUM 값 { "+
-                    "//지난 7일간 자주 착용한 옷 FREQUENT,"+
-                    "//지난 7일간 자주 착용하지 않은 옷 INFREQUENT,"+
-                    "}, query string 입니다."),
-    })
     public BaseResponse<ClothResponseDTO.SmartSummaryClothPreviewListResult> getClothPreviewInfoListByCategoryId(
-            @RequestParam SummaryFrequency type,
             @Parameter(name = "user", hidden = true) @AuthUser Member member
     ) {
         // ClothService를 통해 데이터를 가져오고, 결과 반환
-        ClothResponseDTO.SmartSummaryClothPreviewListResult result = clothService.readSmartSummaryByFrequencyType(type, member.getId());
+        ClothResponseDTO.SmartSummaryClothPreviewListResult result = clothService.readSmartSummary(member.getId());
 
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }
@@ -199,26 +191,24 @@ public class ClothRestController {
 
     // 옷 수정 API
     @PatchMapping(value = "/{clothId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "특정 옷을 수정하는 API", description = "path variable로 cloth_id를 넘겨주세요.\nquery string으로 category_id를 넘겨주세요.\nrequest body에 ClothCreateOrUpdateRequestDTO 형식의 데이터를 전달해주세요.")
+    @Operation(summary = "특정 옷을 수정하는 API", description = "path variable로 cloth_id를 넘겨주세요.\nrequest body에 ClothCreateOrUpdateRequestDTO 형식의 데이터를 전달해주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_204", description = "OK, 성공적으로 수정되었습니다."),
     })
     @Parameters({
             @Parameter(name = "clothId", description = "옷의 id, path variable 입니다."),
-            @Parameter(name = "categoryId", description = "카테고리의 id, query string 입니다.")
     })
     public BaseResponse<ClothResponseDTO.ClothCreateResult> patchCloth(
             @RequestPart("clothUpdateRequest") @Valid @ClothCreateOrUpdateFormat ClothRequestDTO.ClothCreateOrUpdateRequest clothUpdateRequest,
             @RequestPart(value = "imageFile", required = false) @ClothImageFormat MultipartFile imageFile,
             @PathVariable @ClothExist Long clothId,
-            @RequestParam @CategoryExist Long categoryId,
             @Parameter(name = "user", hidden = true) @AuthUser Member member
     ) {
         // 조회하는 현 유저가 옷에 대해서 수정 권한이 있는지 확인합니다.
         clothAccessibleValidator.validateClothOfMember(clothId, member.getId());
 
         // ClothService를 통해 데이터를 수정
-        clothService.updateClothById(clothId, categoryId, clothUpdateRequest, imageFile);
+        clothService.updateClothById(clothId, clothUpdateRequest, imageFile);
 
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_EDITED, null);
     }

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
@@ -17,11 +17,11 @@ public interface ClothService {
 
     ClothResponseDTO.CategoryClothPreviewListResult readClothPreviewInfoListByClokeyId(String ownerClokeyId, Long requesterId, Long categoryId, Season season, ClothSort sort, int page, int pageSize);
 
-    ClothResponseDTO.SmartSummaryClothPreviewListResult readSmartSummaryByFrequencyType(SummaryFrequency frequencyType, Long memberId);
+    ClothResponseDTO.SmartSummaryClothPreviewListResult readSmartSummary(Long memberId);
 
     ClothResponseDTO.ClothCreateResult createCloth(Long memberId, ClothRequestDTO.ClothCreateOrUpdateRequest request, MultipartFile imageFile);
 
-    void updateClothById(Long clothId, Long categoryId, ClothRequestDTO.ClothCreateOrUpdateRequest request, MultipartFile imageFile);
+    void updateClothById(Long clothId, ClothRequestDTO.ClothCreateOrUpdateRequest request, MultipartFile imageFile);
 
     void deleteClothById(Long clothId);
 }

--- a/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
+++ b/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
@@ -119,18 +119,24 @@ public class ClothConverter {
     }
 
     public static ClothResponseDTO.SmartSummaryClothPreviewListResult toSummaryClothPreviewListResult(
-            SummaryFrequency frequencyType,
-            Category category,
-            Double averageUsage,
-            List<ClothResponseDTO.ClothPreview> clothPreviews
+            Category frequentCategory,
+            Category infrequentCategory,
+            Long frequentUsage,
+            Long infrequentUsage,
+            List<ClothResponseDTO.ClothPreview> frequentClothPreviews,
+            List<ClothResponseDTO.ClothPreview> infrequentClothPreviews
     ) {
         return ClothResponseDTO.SmartSummaryClothPreviewListResult.builder()
-                .type(frequencyType)
-                .baseCategoryName(category.getParent().getName())
-                .coreCategoryName(category.getName())
-                .coreCategoryId(category.getId())
-                .averageUsage(averageUsage)
-                .clothPreviews(clothPreviews)
+                .frequentBaseCategoryName(frequentCategory.getParent().getName())
+                .frequentCoreCategoryName(frequentCategory.getName())
+                .frequentCoreCategoryId(frequentCategory.getId())
+                .frequentUsage(frequentUsage)
+                .frequentClothPreviews(frequentClothPreviews)
+                .infrequentBaseCategoryName(infrequentCategory.getParent().getName())
+                .infrequentCoreCategoryName(infrequentCategory.getName())
+                .infrequentCoreCategoryId(infrequentCategory.getId())
+                .infrequentUsage(infrequentUsage)
+                .infrequentClothPreviews(infrequentClothPreviews)
                 .build();
     }
 

--- a/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
@@ -106,11 +106,15 @@ public class ClothResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SmartSummaryClothPreviewListResult {
-        private SummaryFrequency type;
-        private String baseCategoryName;
-        private String coreCategoryName;
-        private Long coreCategoryId;
-        private Double averageUsage;
-        private List<ClothPreview> clothPreviews;
+        private String frequentBaseCategoryName;
+        private String frequentCoreCategoryName;
+        private Long frequentCoreCategoryId;
+        private Long frequentUsage;
+        private List<ClothPreview> frequentClothPreviews;
+        private String infrequentBaseCategoryName;
+        private String infrequentCoreCategoryName;
+        private Long infrequentCoreCategoryId;
+        private Long infrequentUsage;
+        private List<ClothPreview> infrequentClothPreviews;
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #160 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 스마트요약 API에서 빈도수에 따른 타입을 입력받던 것을 없애고 이에 따라 한번에 조회할 수 있도록 수정하였습니다.
- 옷 수정 API의 경우 생성 API와 형식을 맞춰주기 위해서 카테고리 부분을 수정하였습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/66fad501-5518-4b03-94cd-66b7cf6ff015)

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
