### PR TITLE
[refactor/#166] 옷장 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
+++ b/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
@@ -11,7 +11,7 @@ import com.clokey.server.domain.cloth.exception.annotation.ClothImagePresence;
 import com.clokey.server.domain.cloth.exception.validator.ClothAccessibleValidator;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.member.exception.annotation.AuthUser;
-import com.clokey.server.domain.member.exception.annotation.IdValid;
+import com.clokey.server.domain.member.exception.annotation.NullableClokeyIdExist;
 import com.clokey.server.domain.member.exception.validator.MemberAccessibleValidator;
 import com.clokey.server.domain.model.entity.enums.ClothSort;
 import com.clokey.server.domain.model.entity.enums.Season;
@@ -63,32 +63,29 @@ public class ClothRestController {
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }
 
-    // 옷장의 옷 조회 API
-    @GetMapping("/{clokeyId}")
-    @Operation(summary = "유저의 옷장을 조회하는 API", description = "path variable으로 clokeyId를 넘겨주세요" +
-                                                                    "query string으로 category_id를 넘겨주세요." +
-                                                                    "query string으로 season을 넘겨주세요." +
-                                                                    "query string으로 sort를 넘겨주세요." +
-                                                                    "query string으로 page를 넘겨주세요." +
-                                                                    "query string으로 pageSize를 넘겨주세요.")
+    // 옷장의 옷 조회 API (clokeyId를 선택적으로 사용)
+    @GetMapping("/closet-view")
+    @Operation(
+            summary = "유저의 옷장을 조회하는 API",
+            description = "query string로 clokeyId를 선택적으로 넘길 수 있습니다. 전달하지 않을 경우 인증된 사용자의 clokeyId를 사용합니다. " +
+                    "또한 query string으로 category_id, season, sort, page, size를 넘겨주세요."
+    )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_200", description = "OK, 성공적으로 조회되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "CLOTH_200",
+                    description = "OK, 성공적으로 조회되었습니다."
+            )
     })
     @Parameters({
-            @Parameter(name = "clokeyId", description = "클로키 id, path variable 입니다."),
+            @Parameter(name = "clokeyId", description = "클로키 유저의 clokey id, query string 입니다."),
             @Parameter(name = "categoryId", description = "카테고리의 id, query string 입니다."),
             @Parameter(name = "season", description = "계절(Season) ENUM 값 { SPRING, SUMMER, FALL, WINTER }, query string 입니다."),
-            @Parameter(name = "sort", description = "정렬(Sort) ENUM 값 { "+
-                    "//착용순 WEAR,"+
-                    "//미착용순 NOT_WEAR,"+
-                    "//최신등록순 LATEST,"+
-                    "//오래된순 OLDEST,"+
-                    "}, query string 입니다."),
+            @Parameter(name = "sort", description = "정렬(Sort) ENUM 값 { WEAR, NOT_WEAR, LATEST, OLDEST }, query string 입니다."),
             @Parameter(name = "page", description = "페이지 값, query string 입니다."),
             @Parameter(name = "size", description = "페이지에 표시할 요소 개수 값, query string 입니다.")
     })
     public BaseResponse<ClothResponseDTO.CategoryClothPreviewListResult> getClothPreviewInfoListByCategoryId(
-            @PathVariable @IdValid String clokeyId,
+            @RequestParam(value = "clokeyId", required = false) @NullableClokeyIdExist String clokeyId,
             @RequestParam @CategoryExist Long categoryId,
             @RequestParam Season season,
             @RequestParam ClothSort sort,
@@ -96,9 +93,13 @@ public class ClothRestController {
             @RequestParam @CheckPageSize int size,
             @Parameter(name = "user", hidden = true) @AuthUser Member member
     ) {
-        // 조회하는 유저와 다른 유저의 옷장이고, 그 유저가 비공개인 유저인지 확인합니다.
-        memberAccessibleValidator.validateClothAccessOfMember(clokeyId, member.getId());
-
+        if(clokeyId==null || clokeyId.isEmpty()) {
+            clokeyId=member.getClokeyId();
+        }
+        else {
+            // 조회하는 유저와 다른 유저의 옷장이고, 그 유저가 비공개인 유저인지 확인합니다.
+            memberAccessibleValidator.validateClothAccessOfMember(clokeyId, member.getId());
+        }
         // ClothService를 통해 데이터를 가져오고, 결과 반환
         ClothResponseDTO.CategoryClothPreviewListResult result = clothService.readClothPreviewInfoListByClokeyId(clokeyId, member.getId(), categoryId, season, sort, page, size);
 

--- a/src/main/java/com/clokey/server/domain/member/exception/annotation/ClokeyIdExist.java
+++ b/src/main/java/com/clokey/server/domain/member/exception/annotation/ClokeyIdExist.java
@@ -1,0 +1,19 @@
+package com.clokey.server.domain.member.exception.annotation;
+
+import com.clokey.server.domain.member.exception.validator.ClokeyIdExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ClokeyIdExistValidator.class)  // 유효성 검사 로직을 IdExistValidator 클래스에서 처리
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER }) // 메소드, 필드, 파라미터에서 사용 가능
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClokeyIdExist {
+
+    String message() default "존재하지 않는 클로키 아이디입니다.";  // 기본 에러 메시지
+
+    Class<?>[] groups() default {};  // 그룹
+    Class<? extends Payload>[] payload() default {};  // 페이로드
+}

--- a/src/main/java/com/clokey/server/domain/member/exception/validator/ClokeyIdExistValidator.java
+++ b/src/main/java/com/clokey/server/domain/member/exception/validator/ClokeyIdExistValidator.java
@@ -1,0 +1,37 @@
+package com.clokey.server.domain.member.exception.validator;
+
+import com.clokey.server.domain.member.application.MemberRepositoryService;
+import com.clokey.server.domain.member.exception.annotation.ClokeyIdExist;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClokeyIdExistValidator implements ConstraintValidator<ClokeyIdExist, String>{
+
+    private final MemberRepositoryService memberRepositoryService;
+
+    @Override
+    public void initialize(ClokeyIdExist constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+
+        boolean exists=memberRepositoryService.idExist(s);
+
+        if(s==null || exists){
+            return true;
+        }
+        else{
+            constraintValidatorContext.disableDefaultConstraintViolation();
+            constraintValidatorContext.buildConstraintViolationWithTemplate(ErrorStatus.CLOKEY_ID_INVALID.toString()).addConstraintViolation();
+            return false;
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #166 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 클로키 아이디 없이 조회시에 로그인한 유저의 옷장을 조회하도록 수정하였습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 컨트롤러단의 로직 추가
-  API 엔드포인트 수정

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/78df0197-3cc2-4a7a-9ed2-39263b3ae2c8)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
컨트롤러 단에서만 처리하였는데, 이 부분이 괜찮을지 알려주시면 감사하겠습니다.