### PR TITLE
[refactor/#188] 홈-recap 데이터가 아예 없을 때 닉네임 반환하도록 수정

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/history/dto/HistoryResponseDTO.java
@@ -160,21 +160,9 @@ public class HistoryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class HistoryCreateResult{
+    public static class HistoryCreateResult {
         Long historyId;
     }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class LastYearHistoryResult{
-        Boolean isMine;
-        Long historyId;
-        String nickName;
-        List<String> imageUrls;
-    }
-
 }
 
 

--- a/src/main/java/com/clokey/server/domain/recommendation/api/RecommendationController.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/api/RecommendationController.java
@@ -65,8 +65,8 @@ public class RecommendationController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HOME_200", description = "성공적으로 조회되었습니다."),
     })
-    public BaseResponse<HistoryResponseDTO.LastYearHistoryResult> getLastYearHistory(@Parameter(name = "user", hidden = true) @AuthUser Member member) {
-        HistoryResponseDTO.LastYearHistoryResult result = recommendationService.getLastYearHistory(member.getId());
+    public BaseResponse<RecommendationResponseDTO.LastYearHistoryResult> getLastYearHistory(@Parameter(name = "user", hidden = true) @AuthUser Member member) {
+        RecommendationResponseDTO.LastYearHistoryResult result = recommendationService.getLastYearHistory(member.getId());
         return BaseResponse.onSuccess(SuccessStatus.HOME_SUCCESS, result);
     }
 }

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationService.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationService.java
@@ -7,5 +7,5 @@ public interface RecommendationService {
     RecommendationResponseDTO.DailyClothesResult getRecommendClothes(Long memberId, Integer nowTemp, Integer minTemp, Integer maxTemp);
     RecommendationResponseDTO.DailyNewsResult getNews(Long memberId);
     RecommendationResponseDTO.DailyNewsAllResult<?> getNewsAll(Long memberId, String section, Integer page);
-    HistoryResponseDTO.LastYearHistoryResult getLastYearHistory(Long memberId);
+    RecommendationResponseDTO.LastYearHistoryResult getLastYearHistory(Long memberId);
 }

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
@@ -364,8 +364,8 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     @Override
     @Transactional(readOnly = true)
-    public HistoryResponseDTO.LastYearHistoryResult getLastYearHistory(Long memberId) {
-
+    public RecommendationResponseDTO.LastYearHistoryResult getLastYearHistory(Long memberId) {
+        Member member = memberRepositoryService.findMemberById(memberId);
         LocalDate today = LocalDate.now();
         LocalDate oneYearAgo = today.minusYears(1);
 
@@ -374,7 +374,7 @@ public class RecommendationServiceImpl implements RecommendationService {
             List<String> historyUrls = historyImageRepositoryService.findByHistoryId(historyOneYearAgoId).stream()
                     .map(HistoryImage::getImageUrl)
                     .toList();
-            return RecommendationConverter.toLastYearHistoryResult(historyOneYearAgoId,historyUrls,memberRepositoryService.findMemberById(memberId), true);
+            return RecommendationConverter.toLastYearHistoryResult(historyOneYearAgoId, historyUrls, member, true);
         }
 
         List<Long> followingMembers = followRepositoryService.findFollowedByFollowingId(memberId).stream()
@@ -393,7 +393,7 @@ public class RecommendationServiceImpl implements RecommendationService {
             return RecommendationConverter.toLastYearHistoryResult(historyOneYearAgoId,historyUrls,memberRepositoryService.findMemberById(memberPicked), false);
         }
 
-        return null;
+        return RecommendationConverter.toLastYearHistoryResult(null, null, member, true);
     }
 
     private Long getRandomMemberWithHistory(List<Long> followingMembers, List<Boolean> membersHaveHistoryOneYearAgo) {

--- a/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
@@ -126,8 +126,8 @@ public class RecommendationConverter {
                 .build();
     }
 
-    public static HistoryResponseDTO.LastYearHistoryResult toLastYearHistoryResult(Long historyId, List<String> historyImageUrls, Member member, Boolean isMine) {
-        return HistoryResponseDTO.LastYearHistoryResult.builder()
+    public static RecommendationResponseDTO.LastYearHistoryResult toLastYearHistoryResult(Long historyId, List<String> historyImageUrls, Member member, Boolean isMine) {
+        return RecommendationResponseDTO.LastYearHistoryResult.builder()
                 .historyId(historyId)
                 .nickName(member.getNickname())
                 .imageUrls(historyImageUrls)

--- a/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
@@ -109,4 +109,15 @@ public class RecommendationResponseDTO {
         private String imageUrl;
         private Long historyId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LastYearHistoryResult{
+        Boolean isMine;
+        Long historyId;
+        String nickName;
+        List<String> imageUrls;
+    }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #188 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
1년 전 오늘 API에서 데이터가 없을 때 아예 result를 반환하지 않음 
-> nickName 필요해서 제대로 반환하도록 수정

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/92126797-632b-477c-9c1d-57ddb67bde8d)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
