### PR TITLE
[feat/#183] 계정 검색 API 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryService.java
@@ -3,6 +3,7 @@ package com.clokey.server.domain.member.application;
 import com.clokey.server.domain.member.domain.entity.Member;
 
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepositoryService {
@@ -24,4 +25,6 @@ public interface MemberRepositoryService {
     Member findByClokeyId(String clokeyId);
 
     Optional <Member> findMemberByEmail(String email);
+
+    List<Member> findAll();
 }

--- a/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberRepositoryServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -94,6 +95,9 @@ public class MemberRepositoryServiceImpl implements MemberRepositoryService {
         return query.getResultStream().findFirst(); // Optional<Member> 반환
     }
 
-
+    @Override
+    public List<Member> findAll(){
+        return memberRepository.findAll();
+    }
 
 }

--- a/src/main/java/com/clokey/server/domain/member/converter/MemberDocumentConverter.java
+++ b/src/main/java/com/clokey/server/domain/member/converter/MemberDocumentConverter.java
@@ -1,0 +1,40 @@
+package com.clokey.server.domain.member.converter;
+
+import com.clokey.server.domain.member.domain.document.MemberDocument;
+import com.clokey.server.domain.member.dto.MemberDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class MemberDocumentConverter {
+
+    public static <T> List<MemberDTO.ProfilePreview> toProfilePreviewList(Page<? extends T> page){
+        return Optional.ofNullable(page.getContent()).orElse(Collections.emptyList())
+                .stream()
+                .map(item -> {
+                    MemberDocument doc = (MemberDocument) item;
+                    return MemberDTO.ProfilePreview.builder()
+                            .id(doc.getId())
+                            .nickname(doc.getNickname())
+                            .clokeyId(doc.getClokeyId())
+                            .profileImage(doc.getProfileUrl())
+                            .build();
+                }
+            )
+            .collect(Collectors.toList());
+    }
+
+    public static MemberDTO.ProfilePreviewListRP toProfilePreviewListRP(Page<?> page,
+                                                                        List<MemberDTO.ProfilePreview> memberPreviews) {
+        return MemberDTO.ProfilePreviewListRP.builder()
+                .profilePreviews(memberPreviews)
+                .totalPage(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .isFirst(page.isFirst())
+                .isLast(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/clokey/server/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/clokey/server/domain/member/domain/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.clokey.server.domain.member.domain.repository;
 import com.clokey.server.domain.member.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -13,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByClokeyId(String clokeyId);
 
     Optional<Member> findByClokeyId(String clokeyId);
+
+    List<Member> findAll();
 }

--- a/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemberDTO {
 
@@ -66,7 +67,28 @@ public class MemberDTO {
         LocalDateTime updatedAt;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfilePreview {
+        Long id;
+        String nickname;
+        String clokeyId;
+        String profileImage;
+    }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfilePreviewListRP {
+        private List<ProfilePreview> profilePreviews;
+        private int totalPage;
+        private long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
 
     @Builder
     @Getter

--- a/src/main/java/com/clokey/server/domain/search/api/SearchRestController.java
+++ b/src/main/java/com/clokey/server/domain/search/api/SearchRestController.java
@@ -2,6 +2,9 @@ package com.clokey.server.domain.search.api;
 
 import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
 import com.clokey.server.domain.cloth.exception.validator.ClothAccessibleValidator;
+import com.clokey.server.domain.member.domain.entity.Member;
+import com.clokey.server.domain.member.dto.MemberDTO;
+import com.clokey.server.domain.member.exception.annotation.AuthUser;
 import com.clokey.server.domain.member.exception.validator.MemberAccessibleValidator;
 import com.clokey.server.domain.search.application.SearchService;
 import com.clokey.server.global.common.response.BaseResponse;
@@ -33,7 +36,7 @@ public class SearchRestController {
     @PostMapping("/clothes/sync")
     @Operation(summary = "옷 데이터를 Elastic Search에 동기화 시키는 API")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_201", description = "OK, 성공적으로 생성되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH_201", description = "OK, 성공적으로 생성되었습니다."),
     })
     public BaseResponse<Void> syncClothData() throws IOException {
         searchService.syncClothesDataToElasticsearch();
@@ -47,7 +50,7 @@ public class SearchRestController {
             "query string으로 page를 넘겨주세요. " +
             "query string으로 pageSize를 넘겨주세요.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_200", description = "OK, 성공적으로 조회되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH_200", description = "OK, 성공적으로 조회되었습니다."),
     })
     @Parameters({
             @Parameter(name = "by", description = "검색 필터, query string 입니다."),
@@ -55,16 +58,18 @@ public class SearchRestController {
             @Parameter(name = "page", description = "페이지 값, query string 입니다."),
             @Parameter(name = "size", description = "페이지에 표시할 요소 개수 값, query string 입니다.")
     })
-    public BaseResponse<ClothResponseDTO.ClothPreviewListResult> searchClothesByNameOrBrand(
+    public BaseResponse<ClothResponseDTO.ClothPreviewListResult> searchClothes(
             @RequestParam String by,
             @RequestParam String keyword,
             @RequestParam @CheckPage int page,
-            @RequestParam @CheckPageSize int size
+            @RequestParam @CheckPageSize int size,
+            @Parameter(name = "user", hidden = true) @AuthUser Member member
     ) {
+        // By Name Or Brand
         if("name-and-brand".equals(by)) {
             try {
                 ClothResponseDTO.ClothPreviewListResult result = searchService.searchClothesByNameOrBrand(keyword,page,size);
-                return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
+                return BaseResponse.onSuccess(SuccessStatus.SEARCH_SUCCESS, result);
             } catch (IOException e) {
                 return BaseResponse.onFailure(ErrorStatus.SEARCHING_IOEXCEPION, null);
             }
@@ -72,5 +77,53 @@ public class SearchRestController {
         else
             return BaseResponse.onFailure(ErrorStatus.SEARCH_FILTER_ERROR, null);
     }
+
+    // 유저 Elastic Search 동기화 API
+    @PostMapping("/members/sync")
+    @Operation(summary = "유저 데이터를 Elastic Search에 동기화 시키는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH_201", description = "OK, 성공적으로 생성되었습니다."),
+    })
+    public BaseResponse<Void> syncUserData() throws IOException {
+        searchService.syncMembersDataToElasticsearch();
+        return BaseResponse.onSuccess(SuccessStatus.MEMBER_SYNC_CREATED, null);
+    }
+
+    // 유저 검색 API
+    @GetMapping("/members")
+    @Operation(summary = "유저의 클로키ID와 닉네임으로 유저를 검색하는 API", description = "query string으로 keyword를 넘겨주세요" +
+            "query string으로 by를 넘겨주세요. " +
+            "query string으로 page를 넘겨주세요. " +
+            "query string으로 pageSize를 넘겨주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH_200", description = "OK, 성공적으로 조회되었습니다."),
+    })
+    @Parameters({
+            @Parameter(name = "by", description = "검색 필터, query string 입니다."),
+            @Parameter(name = "keyword", description = "검색할 키워드, query string 입니다."),
+            @Parameter(name = "page", description = "페이지 값, query string 입니다."),
+            @Parameter(name = "size", description = "페이지에 표시할 요소 개수 값, query string 입니다.")
+    })
+    public BaseResponse<MemberDTO.ProfilePreviewListRP> searchMembers(
+            @RequestParam String by,
+            @RequestParam String keyword,
+            @RequestParam @CheckPage int page,
+            @RequestParam @CheckPageSize int size,
+            @Parameter(name = "user", hidden = true) @AuthUser Member member
+    ) {
+        // By Id And Nickname
+        if("id-and-nickname".equals(by)) {
+            try {
+                MemberDTO.ProfilePreviewListRP result = searchService.searchMembersByClokeyIdOrNickname(keyword,page,size);
+                return BaseResponse.onSuccess(SuccessStatus.SEARCH_SUCCESS, result);
+            } catch (IOException e) {
+                return BaseResponse.onFailure(ErrorStatus.SEARCHING_IOEXCEPION, null);
+            }
+        }
+        else
+            return BaseResponse.onFailure(ErrorStatus.SEARCH_FILTER_ERROR, null);
+    }
+
+
 
 }

--- a/src/main/java/com/clokey/server/domain/search/application/SearchService.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchService.java
@@ -1,6 +1,9 @@
 package com.clokey.server.domain.search.application;
 
 import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
+import com.clokey.server.domain.member.domain.document.MemberDocument;
+import com.clokey.server.domain.member.dto.MemberDTO;
+import org.springframework.data.domain.Page;
 
 import java.io.IOException;
 
@@ -9,4 +12,13 @@ public interface SearchService {
     void syncClothesDataToElasticsearch() throws IOException;
 
     ClothResponseDTO.ClothPreviewListResult searchClothesByNameOrBrand(String keyword, int page, int size) throws IOException;
+
+    void syncMembersDataToElasticsearch() throws IOException;
+
+    MemberDTO.ProfilePreviewListRP searchMembersByClokeyIdOrNickname(String keyword, int page, int size) throws IOException;
+
+//    void syncHistoriesDataToElasticsearch() throws IOException;
+//
+//    MemberDTO.ProfilePreviewListRP searchMembersByClokeyIdOrNickname(String keyword, int page, int size) throws IOException;
+
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #183 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
계정 검색기능 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- SearchRestController, SearchService 검색 및 동기화 메소드 작성
- MemberService, MemberDocumentConvertor, MemberRepository 등 도메인에서의 서비스 로직 작성 및 수정

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/63eb970d-a120-401c-8743-98a77f44aeeb)
![image](https://github.com/user-attachments/assets/de51191b-a9c6-434a-8b40-dc533898bac2)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
접근 권한 및 validator 작업은 후순위로 미루고 프론트에게 우선 전달해주려 합니다!!