### PR TITLE
[refactor/#201] 검색 API 접근권한 및 validator 적용

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/domain/document/ClothDocument.java
+++ b/src/main/java/com/clokey/server/domain/cloth/domain/document/ClothDocument.java
@@ -1,6 +1,5 @@
 package com.clokey.server.domain.cloth.domain.document;
 
-import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import jakarta.persistence.Id;
 import lombok.*;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -29,13 +28,5 @@ public class ClothDocument {
 
     private Long memberId;
 
-    public static ClothDocument from(Cloth cloth) {
-        return ClothDocument.builder()
-                .id(cloth.getId())
-                .name(cloth.getName())
-                .brand(cloth.getBrand())
-                .imageUrl(cloth.getImage().getImageUrl())
-                .wearNum(cloth.getWearNum())
-                .build();
-    }
+    private String visibility;
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/document/HistoryDocument.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/document/HistoryDocument.java
@@ -25,4 +25,8 @@ public class HistoryDocument {
     private List<String> categoryNames;
 
     private String imageUrl;
+
+    private String memberVisibility;
+
+    private String historyVisibility;
 }

--- a/src/main/java/com/clokey/server/domain/member/domain/document/MemberDocument.java
+++ b/src/main/java/com/clokey/server/domain/member/domain/document/MemberDocument.java
@@ -27,13 +27,4 @@ public class MemberDocument {
     private String clokeyId;
 
     private String profileUrl;
-
-    public static MemberDocument from(Member member) {
-        return MemberDocument.builder()
-                .id(member.getId())
-                .nickname(member.getNickname())
-                .clokeyId(member.getClokeyId())
-                .profileUrl(member.getProfileImageUrl())
-                .build();
-    }
 }

--- a/src/main/java/com/clokey/server/domain/member/domain/document/MemberDocument.java
+++ b/src/main/java/com/clokey/server/domain/member/domain/document/MemberDocument.java
@@ -1,6 +1,5 @@
 package com.clokey.server.domain.member.domain.document;
 
-import com.clokey.server.domain.member.domain.entity.Member;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/clokey/server/domain/member/exception/validator/MemberAccessibleValidator.java
+++ b/src/main/java/com/clokey/server/domain/member/exception/validator/MemberAccessibleValidator.java
@@ -14,7 +14,7 @@ public class MemberAccessibleValidator {
 
     private final MemberRepositoryService memberRepositoryService;
 
-    // 유저가 옷에 대한 접근 권한이 있는지 검증 -> 비공개 옷을 조회하지 못하도록 함
+    // 유저가 옷장에 대한 접근 권한이 있는지 검증 -> 비공개 계정의 옷장을 조회하지 못하도록 함
     public void validateClothAccessOfMember(String ownerClokeyId, Long requesterId) {
         Member member = memberRepositoryService.findByClokeyId(ownerClokeyId);
 

--- a/src/main/java/com/clokey/server/domain/search/api/SearchRestController.java
+++ b/src/main/java/com/clokey/server/domain/search/api/SearchRestController.java
@@ -8,6 +8,7 @@ import com.clokey.server.domain.member.exception.annotation.AuthUser;
 import com.clokey.server.domain.member.exception.annotation.NullableClokeyIdExist;
 import com.clokey.server.domain.member.exception.validator.MemberAccessibleValidator;
 import com.clokey.server.domain.search.application.SearchService;
+import com.clokey.server.domain.search.exception.annotation.KeywordNotNull;
 import com.clokey.server.global.common.response.BaseResponse;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.code.status.SuccessStatus;
@@ -34,7 +35,7 @@ public class SearchRestController {
 
     // 옷 Elastic Search 동기화 API
     @PostMapping("/clothes/sync")
-    @Operation(summary = "옷 데이터를 Elastic Search에 동기화 시키는 API")
+    @Operation(summary = "옷 데이터를 Elastic Search에 동기화 시키는 API (관리자용)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH_201", description = "OK, 성공적으로 생성되었습니다."),
     })
@@ -62,7 +63,7 @@ public class SearchRestController {
     public BaseResponse<ClothResponseDTO.ClothPreviewListResult> searchClothes(
             @RequestParam(value = "clokeyId", required = false) @NullableClokeyIdExist String clokeyId,
             @RequestParam String by,
-            @RequestParam String keyword,
+            @RequestParam @KeywordNotNull String keyword,
             @RequestParam @CheckPage int page,
             @RequestParam @CheckPageSize int size,
             @Parameter(name = "user", hidden = true) @AuthUser Member member
@@ -77,7 +78,7 @@ public class SearchRestController {
         // By Name Or Brand
         if("name-and-brand".equals(by)) {
             try {
-                ClothResponseDTO.ClothPreviewListResult result = searchService.searchClothesByNameOrBrand(clokeyId,keyword,page,size);
+                ClothResponseDTO.ClothPreviewListResult result = searchService.searchClothesByNameOrBrand(member.getId(),clokeyId,keyword,page,size);
                 return BaseResponse.onSuccess(SuccessStatus.SEARCH_SUCCESS, result);
             } catch (IOException e) {
                 return BaseResponse.onFailure(ErrorStatus.SEARCHING_IOEXCEPION, null);
@@ -89,7 +90,7 @@ public class SearchRestController {
 
     // 유저 Elastic Search 동기화 API
     @PostMapping("/members/sync")
-    @Operation(summary = "유저 데이터를 Elastic Search에 동기화 시키는 API")
+    @Operation(summary = "유저 데이터를 Elastic Search에 동기화 시키는 API (관리자용)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH_201", description = "OK, 성공적으로 생성되었습니다."),
     })
@@ -116,7 +117,7 @@ public class SearchRestController {
     })
     public BaseResponse<MemberDTO.ProfilePreviewListRP> searchMembers(
             @RequestParam String by,
-            @RequestParam String keyword,
+            @RequestParam @KeywordNotNull String keyword,
             @RequestParam @CheckPage int page,
             @RequestParam @CheckPageSize int size,
             @Parameter(name = "user", hidden = true) @AuthUser Member member
@@ -136,7 +137,7 @@ public class SearchRestController {
 
     // 기록 Elastic Search 동기화 API
     @PostMapping("/histories/sync")
-    @Operation(summary = "기록 데이터를 Elastic Search에 동기화 시키는 API")
+    @Operation(summary = "기록 데이터를 Elastic Search에 동기화 시키는 API (관리자용)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "SEARCH_201", description = "OK, 성공적으로 생성되었습니다."),
     })
@@ -163,7 +164,7 @@ public class SearchRestController {
     })
     public BaseResponse<HistoryResponseDTO.HistoryPreviewListResult> searchHistories(
             @RequestParam String by,
-            @RequestParam String keyword,
+            @RequestParam @KeywordNotNull String keyword,
             @RequestParam @CheckPage int page,
             @RequestParam @CheckPageSize int size,
             @Parameter(name = "user", hidden = true) @AuthUser Member member

--- a/src/main/java/com/clokey/server/domain/search/application/SearchService.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchService.java
@@ -12,7 +12,7 @@ public interface SearchService {
 
     void syncClothesDataToElasticsearch() throws IOException;
 
-    ClothResponseDTO.ClothPreviewListResult searchClothesByNameOrBrand(String clokeyId, String keyword, int page, int size) throws IOException;
+    ClothResponseDTO.ClothPreviewListResult searchClothesByNameOrBrand(Long requestedMemberId, String clokeyId, String keyword, int page, int size) throws IOException;
 
     void syncMembersDataToElasticsearch() throws IOException;
 

--- a/src/main/java/com/clokey/server/domain/search/exception/annotation/KeywordNotNull.java
+++ b/src/main/java/com/clokey/server/domain/search/exception/annotation/KeywordNotNull.java
@@ -1,0 +1,17 @@
+package com.clokey.server.domain.search.exception.annotation;
+
+import com.clokey.server.domain.search.exception.validator.KeywordNotNullValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = KeywordNotNullValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KeywordNotNull {
+    String message() default "검색어는 필수입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/clokey/server/domain/search/exception/validator/KeywordNotNullValidator.java
+++ b/src/main/java/com/clokey/server/domain/search/exception/validator/KeywordNotNullValidator.java
@@ -1,0 +1,37 @@
+package com.clokey.server.domain.search.exception.validator;
+
+import com.clokey.server.domain.history.application.CommentRepositoryService;
+import com.clokey.server.domain.history.domain.entity.Comment;
+import com.clokey.server.domain.history.exception.annotation.ParentCommentConditions;
+import com.clokey.server.domain.search.exception.annotation.KeywordNotNull;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KeywordNotNullValidator implements ConstraintValidator<KeywordNotNull, String> {
+
+    private final CommentRepositoryService commentRepositoryService;
+
+    @Override
+    public void initialize(KeywordNotNull constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String keyword, ConstraintValidatorContext context) {
+
+        //null인 경우 검증 통과
+        if(keyword == null) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.NO_SUCH_PARAMETER.toString()).addConstraintViolation();
+
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #201 
- close #183 
- close #184 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 옷장 검색 API와 기록 검색 API에 접근권한을 적용했습니다.
- 그 외 validator를 적용했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 키워드 널체크 어노테이션 추가

- 계정검색
계정: 공개 / 비공개 -> 상관없이 다 보여줌 -> 로직 필요 X

- 기록 검색 권한 적용
계정: 공개 & 기록: 공개 -> 보여줌
계정: 공개 & 기록: 비공개 -> 안보여줌
계정: 비공개 & 기록: 공개 -> 안보여줌
계정: 비공개 & 기록: 비공개 -> 안보여줌

  -> 계정이 비공개인 기록은 보여주지 않음 O
  sync시에 아래의 로직으로 memberVisibility 저장
  이 후 쿼리시, memberVisibility:PRIVATE -> 제외

  -> 기록이 비공개인 기록은 보여주지 않음 O
  sync시에 아래의 로직으로 historyVisibility 저장
  이 후 쿼리시, historyVisibility:PRIVATE -> 제외
  
  -> 기록이 공개인데, 옷이 비공개이고, 기록에 옷 등록이 되어있어서 띄워줄 이미지가 없을 때 
  쿼리시 imageUrl : null -> 제외 O

- 옷 검색 권한 적용
계정: 공개 & 옷: 공개 -> 보여줌
계정: 공개 & 옷: 비공개 -> 내 계정으로 검색한 것이 아니면 보여주지 않음
계정: 비공개 & 옷: 공개 -> 검색 불가
계정: 비공개 & 옷: 비공개 -> 검색 불가

  -> 계정이 비공개이면 옷장 검색 불가 O
  memberAccessibleValidator 적용
  
  -> 내 계정으로 검색했으면 비공개여도 모두 보여줌 O
  requestMemberId==memberRepositoryService.findByClokeyId(clokeyId).getId()이면 내 계정으로 검색한 것
  내 계정이면 모두 보여줌
  
  -> 내 계정으로 검색한 것이 아니면 옷이 비공개이면 해당 옷을 보여주지 않음 O
  sync시에 아래의 로직으로 visibility 저장
  visibility:PRIVATE -> 제외

모든 경우 검수 완료했습니다.

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
로직이 부족해 보이는 부분 있다면 피드백 주시면 감사하겠습니다!