### PR TITLE
[feat/#185] JPA 엔티티와 ES 동기화 로직 구현

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothServiceImpl.java
@@ -14,6 +14,8 @@ import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.model.entity.enums.ClothSort;
 import com.clokey.server.domain.model.entity.enums.Season;
 import com.clokey.server.domain.model.entity.enums.SummaryFrequency;
+import com.clokey.server.domain.search.application.SearchRepositoryService;
+import com.clokey.server.domain.search.exception.SearchException;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import com.clokey.server.global.infra.s3.S3ImageService;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,6 +41,7 @@ public class ClothServiceImpl implements ClothService {
     private final HistoryClothRepositoryService historyClothRepositoryService;
     private final HistoryRepositoryService historyRepositoryService;
     private final S3ImageService s3ImageService;
+    private final SearchRepositoryService searchRepositoryService;
 
     public ClothResponseDTO.ClothPopupViewResult readClothPopupInfoById(Long clothId) {
 
@@ -152,6 +156,13 @@ public class ClothServiceImpl implements ClothService {
         // ClothImage 저장
         clothImageRepositoryService.save(clothImage);
 
+        // ES 동기화
+        try {
+            searchRepositoryService.updateClothDataToElasticsearch(cloth);
+        } catch (IOException e) {
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+        }
+
         // Cloth를 응답형식로 변환하여 반환
         return ClothConverter.toClothCreateResult(cloth);
     }
@@ -182,6 +193,13 @@ public class ClothServiceImpl implements ClothService {
                 request.getCategoryId(),
                 imageUrl
         );
+
+        // ES 동기화
+        try {
+            searchRepositoryService.updateClothDataToElasticsearch(existingCloth);
+        } catch (IOException e) {
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+        }
     }
 
     @Transactional
@@ -191,5 +209,12 @@ public class ClothServiceImpl implements ClothService {
         clothFolderRepositoryService.deleteAllByClothId(clothId);
         clothImageRepositoryService.deleteByClothId(clothId);
         clothRepositoryService.deleteById(clothId);
+
+        // ES 삭제
+        try {
+            searchRepositoryService.deleteClothByIdFromElasticsearch(clothId);
+        } catch (IOException e) {
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
+        }
     }
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryServiceImpl.java
@@ -14,6 +14,8 @@ import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.history.converter.HistoryConverter;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
 import com.clokey.server.domain.model.entity.enums.Visibility;
+import com.clokey.server.domain.search.application.SearchRepositoryService;
+import com.clokey.server.domain.search.exception.SearchException;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.clokey.server.global.error.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -24,12 +26,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 @Service
@@ -49,6 +50,7 @@ public class HistoryServiceImpl implements HistoryService {
     private final ClothAccessibleValidator clothAccessibleValidator;
     private final HistoryClothRepositoryService historyClothRepositoryService;
     private final HistoryAccessibleValidator historyAccessibleValidator;
+    private final SearchRepositoryService searchRepositoryService;
 
     @Override
     @Transactional
@@ -250,6 +252,13 @@ public class HistoryServiceImpl implements HistoryService {
                         }
                     });
 
+            // ES 동기화
+            try {
+                searchRepositoryService.updateHistoryDataToElasticsearch(history);
+            } catch (IOException e) {
+                throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+            }
+
             return HistoryConverter.toHistoryCreateResult(history);
         }
     }
@@ -277,6 +286,14 @@ public class HistoryServiceImpl implements HistoryService {
 
         History historyToUpdate = historyRepositoryService.findById(historyId);
         historyToUpdate.updateHistory(historyUpdate.getContent(), historyUpdate.getVisibility());
+
+        // ES 동기화
+        try {
+            searchRepositoryService.updateHistoryDataToElasticsearch(historyToUpdate);
+        } catch (IOException e) {
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+        }
+
         return HistoryConverter.toHistoryCreateResult(historyRepositoryService.findById(historyId));
     }
 
@@ -320,6 +337,13 @@ public class HistoryServiceImpl implements HistoryService {
 
         //기록 삭제
         historyRepositoryService.deleteById(historyId);
+
+        // ES 삭제
+        try {
+            searchRepositoryService.deleteHistoryByIdFromElasticsearch(historyId);
+        } catch (IOException e) {
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
+        }
     }
 
     @Override

--- a/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
@@ -5,11 +5,14 @@ import com.clokey.server.domain.member.exception.MemberException;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.model.entity.enums.RegisterStatus;
 import com.clokey.server.domain.model.entity.enums.SocialType;
+import com.clokey.server.domain.search.application.SearchRepositoryService;
+import com.clokey.server.domain.search.exception.SearchException;
 import com.clokey.server.global.error.code.status.ErrorStatus;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,11 +24,15 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.security.auth.login.LoginException;
+import java.io.IOException;
 import java.util.Date;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
+
+    private final SearchRepositoryService searchRepositoryService;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -119,6 +126,13 @@ public class AuthServiceImpl implements AuthService {
 
         member.updateToken(accessToken, refreshToken);
         memberRepositoryService.saveMember(member);
+
+        // ES 동기화
+        try {
+            searchRepositoryService.updateMemberDataToElasticsearch(member);
+        } catch (IOException e) {
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+        }
 
         // 토큰 반환
         AuthDTO.TokenResponse tokenResponse = new AuthDTO.TokenResponse(

--- a/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryService.java
@@ -1,0 +1,39 @@
+package com.clokey.server.domain.search.application;
+
+import com.clokey.server.domain.cloth.domain.entity.Cloth;
+import com.clokey.server.domain.history.domain.entity.History;
+import com.clokey.server.domain.member.domain.entity.Member;
+
+import java.io.IOException;
+
+public interface SearchRepositoryService {
+
+    // Cloth Sync
+
+    void updateClothDataToElasticsearch(Cloth cloth) throws IOException;
+
+    void deleteClothesByClokeyIdFromElasticsearch(String clokeyId) throws IOException;
+
+    void deleteClothByIdFromElasticsearch(Long clothId) throws IOException;
+
+    void syncAllClothesDataToElasticsearch() throws IOException;
+
+    // History Sync
+
+    void updateHistoryDataToElasticsearch(History history) throws IOException;
+
+    void deleteHistoriesByClokeyIdFromElasticsearch(String clokeyId) throws IOException;
+
+    void deleteHistoryByIdFromElasticsearch(Long historyId) throws IOException;
+
+    void syncAllHistoriesDataToElasticsearch() throws IOException;
+
+    // Member Sync
+
+    void updateMemberDataToElasticsearch(Member member) throws IOException;
+
+    void deleteMemberByClokeyIdFromElasticsearch(String clokeyId) throws IOException;
+
+    void syncAllMembersDataToElasticsearch() throws IOException;
+
+}

--- a/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
@@ -1,0 +1,451 @@
+package com.clokey.server.domain.search.application;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Result;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.elasticsearch.core.DeleteResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+import com.clokey.server.domain.cloth.application.ClothRepositoryService;
+import com.clokey.server.domain.cloth.domain.document.ClothDocument;
+import com.clokey.server.domain.cloth.domain.entity.Cloth;
+import com.clokey.server.domain.history.application.HashtagHistoryRepositoryService;
+import com.clokey.server.domain.history.application.HistoryClothRepositoryService;
+import com.clokey.server.domain.history.application.HistoryImageRepositoryService;
+import com.clokey.server.domain.history.application.HistoryRepositoryService;
+import com.clokey.server.domain.history.domain.document.HistoryDocument;
+import com.clokey.server.domain.history.domain.entity.History;
+import com.clokey.server.domain.history.domain.entity.HistoryImage;
+import com.clokey.server.domain.member.application.MemberRepositoryService;
+import com.clokey.server.domain.member.domain.document.MemberDocument;
+import com.clokey.server.domain.member.domain.entity.Member;
+import com.clokey.server.domain.model.entity.enums.Visibility;
+import com.clokey.server.domain.search.exception.SearchException;
+import com.clokey.server.global.error.code.status.ErrorStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SearchRepositoryServiceImpl implements SearchRepositoryService {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    private final ClothRepositoryService clothRepositoryService;
+    private static final String CLOTH_INDEX_NAME = "cloth";
+
+    private final MemberRepositoryService memberRepositoryService;
+    private static final String MEMBER_INDEX_NAME = "user";
+
+    private final HistoryRepositoryService historyRepositoryService;
+    private final HashtagHistoryRepositoryService hashtagHistoryRepositoryService;
+    private final HistoryClothRepositoryService historyClothRepositoryService;
+    private final HistoryImageRepositoryService historyImageRepositoryService;
+    private static final String HISTORY_INDEX_NAME = "history";
+
+    /****************************************Cloth Sync****************************************/
+
+    // 단일 옷 데이터를 Elasticsearch로 저장하는 메서드
+    @Override
+    @Transactional
+    public void updateClothDataToElasticsearch(Cloth cloth) throws IOException {
+        // Elasticsearch 문서 변환
+        BulkOperation bulkOperation = BulkOperation.of(op -> op
+                .index(IndexOperation.of(idx -> idx
+                        .index(CLOTH_INDEX_NAME) // Elasticsearch 인덱스명
+                        .id(cloth.getId().toString()) // ID 설정
+                        .document(ClothDocument.builder()
+                                .id(cloth.getId())
+                                .name(cloth.getName())
+                                .brand(cloth.getBrand())
+                                .imageUrl(cloth.getImage() != null ? cloth.getImage().getImageUrl() : null)
+                                .wearNum(cloth.getWearNum())
+                                .memberId(cloth.getMember().getId())
+                                .visibility(cloth.getVisibility().toString())
+                                .build())
+                )));
+
+        // Bulk 요청 실행 (단일 문서 업데이트)
+        BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
+                .index(CLOTH_INDEX_NAME)
+                .operations(List.of(bulkOperation))
+        );
+
+        // Bulk 처리 결과 로그 출력
+        if (bulkResponse.errors()) {
+            // 오류 발생 시 로그 출력
+            System.err.println("Elasticsearch 단일 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+        }
+    }
+
+    // 특정 clokeyId를 가진 멤버의 Elasticsearch의 모든 옷 데이터 삭제하는 메서드
+    @Override
+    @Transactional
+    public void deleteClothesByClokeyIdFromElasticsearch(String clokeyId) throws IOException {
+        // 클로키 ID로 해당 멤버 찾기
+        Member member = memberRepositoryService.findMemberByClokeyId(clokeyId);
+        Long memberId = member.getId(); // 해당 멤버의 ID 가져오기
+
+        // Elasticsearch에서 해당 memberId를 가진 모든 Cloth 삭제
+        DeleteByQueryResponse deleteResponse = elasticsearchClient.deleteByQuery(d -> d
+                .index(CLOTH_INDEX_NAME)
+                .query(q -> q
+                        .term(t -> t.field("memberId").value(memberId)) // 특정 memberId의 모든 Cloth 삭제
+                )
+        );
+
+        // 삭제 처리 결과 로그 출력
+        if (deleteResponse.deleted() == 0) {
+            // 오류 발생 시 삭제 실패 로그 출력
+            System.err.println("Elasticsearch에서 clokeyId: " + clokeyId + " 에 해당하는 옷 데이터를 찾을 수 없습니다.");
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
+        }
+    }
+
+    // 특정 옷 Elasticsearch에서 삭제하는 메서드
+    @Override
+    @Transactional
+    public void deleteClothByIdFromElasticsearch(Long clothId) throws IOException {
+        // Elasticsearch에서 해당 clothId에 해당하는 데이터 삭제
+        DeleteResponse deleteResponse = elasticsearchClient.delete(d -> d
+                .index(CLOTH_INDEX_NAME)
+                .id(clothId.toString()) // clothId에 해당하는 단일 문서 삭제
+        );
+
+        // 삭제 처리 결과 로그 출력
+        if (!deleteResponse.result().equals(Result.Deleted)) {
+            // 오류 발생 시 삭제 실패 로그 출력
+            System.err.println("Elasticsearch에서 clothId: " + clothId + " 에 해당하는 데이터를 찾을 수 없습니다.");
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
+        }
+    }
+
+    // JPA에서 모든 Cloth 데이터 가져와서 Elasticsearch로 저장하는 메서드
+    @Override
+    @Transactional
+    public void syncAllClothesDataToElasticsearch() throws IOException {
+        // JPA에서 모든 데이터 조회
+        List<Cloth> clothList = clothRepositoryService.findAll();
+
+        // Cloth 데이터를 Elasticsearch 문서로 변환
+        List<BulkOperation> bulkOperations = clothList.stream()
+                .map(cloth -> BulkOperation.of(op -> op
+                        .index(IndexOperation.of(idx -> idx
+                                .index(CLOTH_INDEX_NAME) // Elasticsearch 인덱스명
+                                .id(cloth.getId().toString()) // ID 설정
+                                .document(ClothDocument.builder()
+                                        .id(cloth.getId())
+                                        .name(cloth.getName())
+                                        .brand(cloth.getBrand())
+                                        .imageUrl(cloth.getImage() != null ? cloth.getImage().getImageUrl() : null)
+                                        .wearNum(cloth.getWearNum())
+                                        .memberId(cloth.getMember().getId())
+                                        .visibility(cloth.getVisibility().toString())
+                                        .build())
+                        ))))
+                .collect(Collectors.toList());
+
+        // Bulk 요청 실행
+        if (!bulkOperations.isEmpty()) {
+            BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
+                    .index(CLOTH_INDEX_NAME)
+                    .operations(bulkOperations)
+            );
+
+            // Bulk 처리 결과 로그 출력
+            if (bulkResponse.errors()) {
+                // 오류 발생 시 BulkResponse를 로그로 출력
+                System.err.println("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
+
+                throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+            }
+        }
+    }
+
+    /****************************************History Sync****************************************/
+
+    // 단일 기록 데이터를 Elasticsearch로 저장하는 메서드
+    @Override
+    @Transactional
+    public void updateHistoryDataToElasticsearch(History history) throws IOException {
+        // Hashtag 가져오기
+        List<String> hashtagNames = hashtagHistoryRepositoryService.findHashtagNamesByHistoryId(history.getId());
+
+        // 태그된 cloth 가져오기
+        List<Cloth> clothes = historyClothRepositoryService.findAllClothByHistoryId(history.getId());
+
+        // Category 가져오기 (태그된 cloth 기반)
+        List<String> categoryNames = clothes.stream()
+                .map(cloth -> cloth.getCategory().getName()) // Cloth에서 직접 Category 가져오기
+                .distinct() // 중복 제거
+                .collect(Collectors.toList());
+
+        // Image URL 가져오기 (공개된 첫 번째 옷 이미지)
+        List<String> imageUrls = historyImageRepositoryService.findByHistoryId(history.getId()).stream()
+                .sorted(Comparator.comparing(HistoryImage::getCreatedAt))
+                .map(HistoryImage::getImageUrl)
+                .toList();
+
+        // 첫 번째 이미지 선택 (없다면 대체 이미지 가져오기)
+        String imageUrl = imageUrls.isEmpty()
+                ? historyClothRepositoryService.findAllClothByHistoryId(history.getId()).stream()
+                .filter(cloth -> !cloth.getVisibility().equals(Visibility.PRIVATE))
+                .findFirst()
+                .map(cloth -> cloth.getImage() != null ? cloth.getImage().getImageUrl() : null)
+                .orElse("null")
+                : imageUrls.get(0);
+
+        // Elasticsearch 문서 변환
+        BulkOperation bulkOperation = BulkOperation.of(op -> op
+                .index(IndexOperation.of(idx -> idx
+                        .index(HISTORY_INDEX_NAME)
+                        .id(history.getId().toString()) // ID 설정
+                        .document(HistoryDocument.builder()
+                                .id(history.getId())
+                                .hashtagNames(hashtagNames)
+                                .categoryNames(categoryNames)
+                                .imageUrl(imageUrl)
+                                .memberVisibility(history.getMember().getVisibility().toString())
+                                .historyVisibility(history.getVisibility().toString())
+                                .build())
+                )));
+
+        // Bulk 요청 실행 (단일 문서 업데이트)
+        BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
+                .index(HISTORY_INDEX_NAME)
+                .operations(List.of(bulkOperation))
+        );
+
+        // Bulk 처리 결과 로그 출력
+        if (bulkResponse.errors()) {
+            // 오류 발생 시 로그 출력
+            System.err.println("Elasticsearch 단일 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+        }
+    }
+
+    // 특정 clokeyId를 가진 멤버의 Elasticsearch의 모든 기록 데이터 삭제하는 메서드
+    @Override
+    @Transactional
+    public void deleteHistoriesByClokeyIdFromElasticsearch(String clokeyId) throws IOException {
+        // 클로키 ID로 해당 멤버 찾기
+        Member member = memberRepositoryService.findMemberByClokeyId(clokeyId);
+        Long memberId = member.getId(); // 해당 멤버의 ID 가져오기
+
+        // Elasticsearch에서 해당 memberId를 가진 모든 History 삭제
+        DeleteByQueryResponse deleteResponse = elasticsearchClient.deleteByQuery(d -> d
+                .index(HISTORY_INDEX_NAME)
+                .query(q -> q
+                        .term(t -> t.field("memberId").value(memberId)) // 특정 memberId의 모든 History 삭제
+                )
+        );
+
+        // 삭제 처리 결과 로그 출력
+        if (deleteResponse.deleted() == 0) {
+            // 오류 발생 시 삭제 실패 로그 출력
+            System.err.println("Elasticsearch에서 clokeyId: " + clokeyId + " 에 해당하는 옷 데이터를 찾을 수 없습니다.");
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
+        }
+    }
+
+    // 특정 옷 Elasticsearch에서 삭제하는 메서드
+    @Override
+    @Transactional
+    public void deleteHistoryByIdFromElasticsearch(Long historyId) throws IOException {
+        // Elasticsearch에서 해당 historyId에 해당하는 데이터 삭제
+        DeleteResponse deleteResponse = elasticsearchClient.delete(d -> d
+                .index(HISTORY_INDEX_NAME)
+                .id(historyId.toString()) // historyId에 해당하는 단일 문서 삭제
+        );
+
+        // 삭제 처리 결과 로그 출력
+        if (!deleteResponse.result().equals(Result.Deleted)) {
+            // 오류 발생 시 삭제 실패 로그 출력
+            System.err.println("Elasticsearch에서 clothId: " + historyId + " 에 해당하는 데이터를 찾을 수 없습니다.");
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
+        }
+    }
+
+    // JPA에서 모든 History 데이터 가져와서 Elasticsearch로 저장하는 메서드
+    @Override
+    @Transactional
+    public void syncAllHistoriesDataToElasticsearch() throws IOException {
+        // JPA에서 모든 History 데이터 조회
+        List<History> historyList = historyRepositoryService.findAll();
+
+        // History 데이터를 Elasticsearch 문서로 변환
+        List<BulkOperation> bulkOperations = historyList.stream()
+                .map(history -> {
+
+                    // Hashtag 가져오기
+                    List<String> hashtagNames = hashtagHistoryRepositoryService.findHashtagNamesByHistoryId(history.getId());
+
+                    // 태그된 cloth 가져오기
+                    List<Cloth> clothes = historyClothRepositoryService.findAllClothByHistoryId(history.getId());
+
+                    // Category 가져오기 (태그된 cloth 기반)
+                    List<String> categoryNames = clothes.stream()
+                            .map(cloth -> cloth.getCategory().getName()) // Cloth에서 직접 Category 가져오기
+                            .distinct() // 중복 제거
+                            .collect(Collectors.toList());
+
+                    // Image URL 가져오기
+                    // HistoryImage에서 가장 먼저 생성된 이미지 가져오기
+                    List<String> imageUrls = historyImageRepositoryService.findByHistoryId(history.getId()).stream()
+                            .sorted(Comparator.comparing(HistoryImage::getCreatedAt)) // 생성일 기준 정렬
+                            .map(HistoryImage::getImageUrl)
+                            .toList();
+
+                    // 첫 번째 이미지 선택 (없다면 대체 이미지 가져오기)
+                    String imageUrl = imageUrls.isEmpty()
+                            ? historyClothRepositoryService.findAllClothByHistoryId(history.getId()).stream() // HistoryImage가 없다면 첫 번째 공개된 옷사진으로 대체
+                            .filter(cloth -> !cloth.getVisibility().equals(Visibility.PRIVATE)) // 비공개 옷 제외
+                            .findFirst()  // 첫 번째 공개된 옷의 URL 반환
+                            .map(cloth -> cloth.getImage() != null ? cloth.getImage().getImageUrl() : null) // 이미지 존재 여부 확인
+                            .orElse("null")
+                            : imageUrls.get(0); // 존재하면 첫 번째 이미지 사용
+
+                    return BulkOperation.of(op -> op
+                            .index(IndexOperation.of(idx -> idx
+                                    .index(HISTORY_INDEX_NAME) // Elasticsearch 인덱스명
+                                    .id(history.getId().toString()) // ID 설정
+                                    .document(HistoryDocument.builder()
+                                            .id(history.getId())
+                                            .hashtagNames(hashtagNames)
+                                            .categoryNames(categoryNames)
+                                            .imageUrl(imageUrl)
+                                            .memberVisibility(history.getMember().getVisibility().toString())
+                                            .historyVisibility(history.getVisibility().toString())
+                                            .build())
+                            )));
+                })
+                .collect(Collectors.toList());
+
+        // Bulk 요청 실행
+        if (!bulkOperations.isEmpty()) {
+            BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
+                    .index(HISTORY_INDEX_NAME)
+                    .operations(bulkOperations)
+            );
+
+            // Bulk 처리 결과 로그 출력
+            if (bulkResponse.errors()) {
+                // 오류 발생 시 BulkResponse를 로그로 출력
+                System.err.println("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
+
+                throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+            }
+        }
+    }
+
+    /****************************************Member Sync****************************************/
+
+    // 단일 유저 데이터를 Elasticsearch로 저장하는 메서드
+    @Override
+    @Transactional
+    public void updateMemberDataToElasticsearch(Member member) throws IOException {
+        // Elasticsearch 문서 변환
+        BulkOperation bulkOperation = BulkOperation.of(op -> op
+                .index(IndexOperation.of(idx -> idx
+                        .index(MEMBER_INDEX_NAME) // Elasticsearch 인덱스명
+                        .id(member.getId().toString()) // ID 설정
+                        .document(MemberDocument.builder()
+                                .id(member.getId())
+                                .nickname(member.getNickname())
+                                .clokeyId(member.getClokeyId())
+                                .profileUrl(member.getProfileImageUrl())
+                                .build())
+                )));
+
+        // Bulk 요청 실행 (단일 문서 업데이트)
+        BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
+                .index(MEMBER_INDEX_NAME)
+                .operations(List.of(bulkOperation))
+        );
+
+        // Bulk 처리 결과 로그 출력
+        if (bulkResponse.errors()) {
+            // 오류 발생 시 로그 출력
+            System.err.println("Elasticsearch 단일 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+        }
+    }
+
+    // 특정 clokeyId를 가진 멤버의 Elasticsearch의 유저 데이터 삭제하는 메서드
+    @Override
+    @Transactional
+    public void deleteMemberByClokeyIdFromElasticsearch(String clokeyId) throws IOException {
+        // 클로키 ID로 해당 멤버 찾기
+        Member member = memberRepositoryService.findMemberByClokeyId(clokeyId);
+        Long memberId = member.getId(); // 해당 멤버의 ID 가져오기
+
+        // Elasticsearch에서 해당 memberId에 해당하는 문서 삭제
+        DeleteResponse deleteResponse = elasticsearchClient.delete(d -> d
+                .index(MEMBER_INDEX_NAME)
+                .id(memberId.toString()) // memberId를 기반으로 삭제
+        );
+
+        // 삭제 처리 결과 로그 출력
+        if (!deleteResponse.result().equals(Result.Deleted)) {
+            // 오류 발생 시 삭제 실패 로그 출력
+            System.err.println("Elasticsearch에서 clothId: " + clokeyId + " 에 해당하는 데이터를 찾을 수 없습니다.");
+
+            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
+        }
+    }
+
+    // JPA에서 모든 Member 데이터 가져와서 Elasticsearch로 저장하는 메서드
+    @Override
+    @Transactional
+    public void syncAllMembersDataToElasticsearch() throws IOException {
+        // JPA에서 모든 Member 데이터 조회
+        List<Member> memberList = memberRepositoryService.findAll();
+
+        // Member 데이터를 Elasticsearch 문서로 변환
+        List<BulkOperation> bulkOperations = memberList.stream()
+                .map(member -> BulkOperation.of(op -> op
+                        .index(IndexOperation.of(idx -> idx
+                                .index(MEMBER_INDEX_NAME) // Elasticsearch 인덱스명
+                                .id(member.getId().toString()) // ID 설정
+                                .document(MemberDocument.builder()
+                                        .id(member.getId())
+                                        .nickname(member.getNickname())
+                                        .clokeyId(member.getClokeyId())
+                                        .profileUrl(member.getProfileImageUrl())
+                                        .build())
+                        ))))
+                .collect(Collectors.toList());
+
+        // Bulk 요청 실행
+        if (!bulkOperations.isEmpty()) {
+            BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
+                    .index(MEMBER_INDEX_NAME)
+                    .operations(bulkOperations)
+            );
+
+            // Bulk 처리 결과 로그 출력
+            if (bulkResponse.errors()) {
+                // 오류 발생 시 BulkResponse를 로그로 출력
+                System.err.println("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
+
+                throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/clokey/server/domain/search/application/SearchService.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchService.java
@@ -1,25 +1,19 @@
 package com.clokey.server.domain.search.application;
 
+import com.clokey.server.domain.cloth.domain.entity.Cloth;
 import com.clokey.server.domain.cloth.dto.ClothResponseDTO;
+import com.clokey.server.domain.history.domain.entity.History;
 import com.clokey.server.domain.history.dto.HistoryResponseDTO;
-import com.clokey.server.domain.member.domain.document.MemberDocument;
+import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.member.dto.MemberDTO;
-import org.springframework.data.domain.Page;
 
 import java.io.IOException;
 
 public interface SearchService {
 
-    void syncClothesDataToElasticsearch() throws IOException;
-
     ClothResponseDTO.ClothPreviewListResult searchClothesByNameOrBrand(Long requestedMemberId, String clokeyId, String keyword, int page, int size) throws IOException;
-
-    void syncMembersDataToElasticsearch() throws IOException;
-
-    MemberDTO.ProfilePreviewListRP searchMembersByClokeyIdOrNickname(String keyword, int page, int size) throws IOException;
-
-    void syncHistoriesDataToElasticsearch() throws IOException;
 
     HistoryResponseDTO.HistoryPreviewListResult searchHistoriesByHashtagAndCategory(String keyword, int page, int size) throws IOException;
 
+    MemberDTO.ProfilePreviewListRP searchMembersByClokeyIdOrNickname(String keyword, int page, int size) throws IOException;
 }

--- a/src/main/java/com/clokey/server/domain/search/application/SearchServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchServiceImpl.java
@@ -2,8 +2,11 @@ package com.clokey.server.domain.search.application;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.Result;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQueryField;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.elasticsearch.core.DeleteResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
@@ -28,6 +31,8 @@ import com.clokey.server.domain.member.domain.document.MemberDocument;
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.member.dto.MemberDTO;
 import com.clokey.server.domain.model.entity.enums.Visibility;
+import com.clokey.server.domain.search.exception.SearchException;
+import com.clokey.server.global.error.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -47,57 +52,18 @@ public class SearchServiceImpl implements SearchService {
 
     private final ElasticsearchClient elasticsearchClient;
 
-    private final ClothRepositoryService clothRepositoryService;
-    private static final String CLOTH_INDEX_NAME = "cloth";
-
     private final MemberRepositoryService memberRepositoryService;
+
     private static final String MEMBER_INDEX_NAME = "user";
 
-    private final HistoryRepositoryService historyRepositoryService;
-    private final HashtagHistoryRepositoryService hashtagHistoryRepositoryService;
-    private final HistoryClothRepositoryService historyClothRepositoryService;
-    private final HistoryImageRepositoryService historyImageRepositoryService;
+    private static final String CLOTH_INDEX_NAME = "cloth";
+
     private static final String HISTORY_INDEX_NAME = "history";
 
-    // JPA에서 모든 Cloth 데이터 가져와서 Elasticsearch로 저장하는 메서드
-    @Transactional
-    public void syncClothesDataToElasticsearch() throws IOException {
-        // JPA에서 모든 데이터 조회
-        List<Cloth> clothList = clothRepositoryService.findAll();
-
-        // Cloth 데이터를 Elasticsearch 문서로 변환
-        List<BulkOperation> bulkOperations = clothList.stream()
-                .map(cloth -> BulkOperation.of(op -> op
-                        .index(IndexOperation.of(idx -> idx
-                                .index(CLOTH_INDEX_NAME) // Elasticsearch 인덱스명
-                                .id(cloth.getId().toString()) // ID 설정
-                                .document(ClothDocument.builder()
-                                        .id(cloth.getId())
-                                        .name(cloth.getName())
-                                        .brand(cloth.getBrand())
-                                        .imageUrl(cloth.getImage() != null ? cloth.getImage().getImageUrl() : null)
-                                        .wearNum(cloth.getWearNum())
-                                        .memberId(cloth.getMember().getId())
-                                        .visibility(cloth.getVisibility().toString())
-                                        .build())
-                        ))))
-                .collect(Collectors.toList());
-
-        // Bulk 요청 실행
-        if (!bulkOperations.isEmpty()) {
-            BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
-                    .index(CLOTH_INDEX_NAME)
-                    .operations(bulkOperations)
-            );
-
-            // Bulk 처리 결과 로그 출력
-            if (bulkResponse.errors()) {
-                throw new RuntimeException("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
-            }
-        }
-    }
+    /****************************************Search Method****************************************/
 
     // 옷 이름과 브랜드로 검색하는 메서드
+    @Override
     public ClothResponseDTO.ClothPreviewListResult searchClothesByNameOrBrand(Long requestedMemberId, String clokeyId, String keyword, int page, int size) throws IOException {
 
         Pageable pageable = PageRequest.of(page-1, size);
@@ -150,148 +116,8 @@ public class SearchServiceImpl implements SearchService {
         return ClothConverter.toClothPreviewListResult(clothDocuments, clothPreviews);
     }
 
-    // JPA에서 모든 Member 데이터 가져와서 Elasticsearch로 저장하는 메서드
-    @Transactional
-    public void syncMembersDataToElasticsearch() throws IOException {
-        // JPA에서 모든 Member 데이터 조회
-        List<Member> memberList = memberRepositoryService.findAll();
-
-        // Member 데이터를 Elasticsearch 문서로 변환
-        List<BulkOperation> bulkOperations = memberList.stream()
-                .map(member -> BulkOperation.of(op -> op
-                        .index(IndexOperation.of(idx -> idx
-                                .index(MEMBER_INDEX_NAME) // Elasticsearch 인덱스명
-                                .id(member.getId().toString()) // ID 설정
-                                .document(MemberDocument.builder()
-                                        .id(member.getId())
-                                        .nickname(member.getNickname())
-                                        .clokeyId(member.getClokeyId())
-                                        .profileUrl(member.getProfileImageUrl())
-                                        .build())
-                        ))))
-                .collect(Collectors.toList());
-
-        // Bulk 요청 실행
-        if (!bulkOperations.isEmpty()) {
-            BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
-                    .index(MEMBER_INDEX_NAME)
-                    .operations(bulkOperations)
-            );
-
-            // Bulk 처리 결과 로그 출력
-            if (bulkResponse.errors()) {
-                throw new RuntimeException("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
-            }
-        }
-    }
-
-    // 유저의 Clokey Id 또는 닉네임으로 검색하는 메서드
-    public MemberDTO.ProfilePreviewListRP searchMembersByClokeyIdOrNickname(String keyword, int page, int size) throws IOException {
-
-        Pageable pageable = PageRequest.of(page - 1, size);
-
-        SearchResponse<MemberDocument> response = elasticsearchClient.search(s -> s
-                        .index(MEMBER_INDEX_NAME)
-                        .query(q -> q.bool(b -> b
-                                .should(m -> m.multiMatch(t -> t
-                                        .query(keyword)
-                                        .fields("clokeyId", "nickname")
-                                        .fuzziness("AUTO")
-                                ))
-                                .should(m -> m.matchBoolPrefix(t -> t
-                                        .field("clokeyId")
-                                        .query(keyword)
-                                ))
-                                .should(m -> m.matchBoolPrefix(t -> t
-                                        .field("nickname")
-                                        .query(keyword)
-                                ))
-                        )),
-                MemberDocument.class
-        );
-
-        List<MemberDocument> results = response.hits().hits().stream()
-                .map(Hit::source)
-                .collect(Collectors.toList());
-
-        Page<MemberDocument> memberDocuments = new PageImpl<>(results, pageable, response.hits().total().value());
-
-        // Member Document -> ProfilePreview DTO 변환
-        List<MemberDTO.ProfilePreview> memberPreviews = MemberDocumentConverter.toProfilePreviewList(memberDocuments);
-
-        // 페이징 정보를 담아 DTO 반환
-        return MemberDocumentConverter.toProfilePreviewListRP(memberDocuments, memberPreviews);
-    }
-
-    // JPA에서 모든 History 데이터 가져와서 Elasticsearch로 저장하는 메서드
-    @Transactional
-    public void syncHistoriesDataToElasticsearch() throws IOException {
-        // JPA에서 모든 History 데이터 조회
-        List<History> historyList = historyRepositoryService.findAll();
-
-        // History 데이터를 Elasticsearch 문서로 변환
-        List<BulkOperation> bulkOperations = historyList.stream()
-                .map(history -> {
-
-                    // Hashtag 가져오기
-                    List<String> hashtagNames = hashtagHistoryRepositoryService.findHashtagNamesByHistoryId(history.getId());
-
-                    // 태그된 cloth 가져오기
-                    List<Cloth> clothes = historyClothRepositoryService.findAllClothByHistoryId(history.getId());
-
-                    // Category 가져오기 (태그된 cloth 기반)
-                    List<String> categoryNames = clothes.stream()
-                            .map(cloth -> cloth.getCategory().getName()) // Cloth에서 직접 Category 가져오기
-                            .distinct() // 중복 제거
-                            .collect(Collectors.toList());
-
-                    // Image URL 가져오기
-                    // HistoryImage에서 가장 먼저 생성된 이미지 가져오기
-                    List<String> imageUrls = historyImageRepositoryService.findByHistoryId(history.getId()).stream()
-                            .sorted(Comparator.comparing(HistoryImage::getCreatedAt)) // 생성일 기준 정렬
-                            .map(HistoryImage::getImageUrl)
-                            .toList();
-
-                    // 첫 번째 이미지 선택 (없다면 대체 이미지 가져오기)
-                    String imageUrl = imageUrls.isEmpty()
-                            ? historyClothRepositoryService.findAllClothByHistoryId(history.getId()).stream() // HistoryImage가 없다면 첫 번째 공개된 옷사진으로 대체
-                            .filter(cloth -> !cloth.getVisibility().equals(Visibility.PRIVATE)) // 비공개 옷 제외
-                            .findFirst()  // 첫 번째 공개된 옷의 URL 반환
-                            .map(cloth -> cloth.getImage() != null ? cloth.getImage().getImageUrl() : null) // 이미지 존재 여부 확인
-                            .orElse("null")
-                            : imageUrls.get(0); // 존재하면 첫 번째 이미지 사용
-
-                    return BulkOperation.of(op -> op
-                            .index(IndexOperation.of(idx -> idx
-                                    .index(HISTORY_INDEX_NAME) // Elasticsearch 인덱스명
-                                    .id(history.getId().toString()) // ID 설정
-                                    .document(HistoryDocument.builder()
-                                            .id(history.getId())
-                                            .hashtagNames(hashtagNames)
-                                            .categoryNames(categoryNames)
-                                            .imageUrl(imageUrl)
-                                            .memberVisibility(history.getMember().getVisibility().toString())
-                                            .historyVisibility(history.getVisibility().toString())
-                                            .build())
-                            )));
-                })
-                .collect(Collectors.toList());
-
-        // Bulk 요청 실행
-        if (!bulkOperations.isEmpty()) {
-            BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
-                    .index(HISTORY_INDEX_NAME)
-                    .operations(bulkOperations)
-            );
-
-            // Bulk 처리 결과 로그 출력
-            if (bulkResponse.errors()) {
-                throw new RuntimeException("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
-            }
-        }
-    }
-
     // 기록의 해쉬태그와 카테고리로 검색하는 메서드
+    @Override
     public HistoryResponseDTO.HistoryPreviewListResult searchHistoriesByHashtagAndCategory(String keyword, int page, int size) throws IOException {
 
         Pageable pageable = PageRequest.of(page - 1, size);
@@ -335,5 +161,44 @@ public class SearchServiceImpl implements SearchService {
 
         // 페이징 정보를 담아 DTO 반환
         return HistoryConverter.toHistoryPreviewListResult(historyDocuments, historyPreviews);
+    }
+
+    // 유저의 Clokey Id 또는 닉네임으로 검색하는 메서드
+    @Override
+    public MemberDTO.ProfilePreviewListRP searchMembersByClokeyIdOrNickname(String keyword, int page, int size) throws IOException {
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        SearchResponse<MemberDocument> response = elasticsearchClient.search(s -> s
+                        .index(MEMBER_INDEX_NAME)
+                        .query(q -> q.bool(b -> b
+                                .should(m -> m.multiMatch(t -> t
+                                        .query(keyword)
+                                        .fields("clokeyId", "nickname")
+                                        .fuzziness("AUTO")
+                                ))
+                                .should(m -> m.matchBoolPrefix(t -> t
+                                        .field("clokeyId")
+                                        .query(keyword)
+                                ))
+                                .should(m -> m.matchBoolPrefix(t -> t
+                                        .field("nickname")
+                                        .query(keyword)
+                                ))
+                        )),
+                MemberDocument.class
+        );
+
+        List<MemberDocument> results = response.hits().hits().stream()
+                .map(Hit::source)
+                .collect(Collectors.toList());
+
+        Page<MemberDocument> memberDocuments = new PageImpl<>(results, pageable, response.hits().total().value());
+
+        // Member Document -> ProfilePreview DTO 변환
+        List<MemberDTO.ProfilePreview> memberPreviews = MemberDocumentConverter.toProfilePreviewList(memberDocuments);
+
+        // 페이징 정보를 담아 DTO 반환
+        return MemberDocumentConverter.toProfilePreviewListRP(memberDocuments, memberPreviews);
     }
 }

--- a/src/main/java/com/clokey/server/domain/search/exception/validator/KeywordNotNullValidator.java
+++ b/src/main/java/com/clokey/server/domain/search/exception/validator/KeywordNotNullValidator.java
@@ -24,8 +24,8 @@ public class KeywordNotNullValidator implements ConstraintValidator<KeywordNotNu
     @Override
     public boolean isValid(String keyword, ConstraintValidatorContext context) {
 
-        //null인 경우 검증 통과
-        if(keyword == null) {
+        //null인 경우 검증 실패
+        if(keyword == null||keyword.isEmpty()) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(ErrorStatus.NO_SUCH_PARAMETER.toString()).addConstraintViolation();
 

--- a/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/clokey/server/global/error/code/status/ErrorStatus.java
@@ -113,14 +113,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //검색 에러
     NO_SUCH_PARAMETER(HttpStatus.BAD_REQUEST,"SEARCH_4001","검색어는 필수입니다."),
-    Elastic_Search_Transport_Exception(HttpStatus.BAD_REQUEST,"SEARCH_4002","Elastic Search 연결 에러입니다."),
-    Index_Not_Fount_Exception(HttpStatus.BAD_REQUEST,"SEARCH_4003","Elastic Search에서 지정한 인덱스가 없습니다."),
-    Mapper_Parsing_Exception(HttpStatus.BAD_REQUEST,"SEARCH_4004","Elastic Search 문서 필드의 타입과 정의된 도메인 모델의 필드 타입이 일치하지 않습니다."),
     SEARCH_CLOTH_ERROR(HttpStatus.BAD_REQUEST,"SEARCH_500","옷 검색 에러입니다."),
     SEARCH_HISTORY_ERROR(HttpStatus.BAD_REQUEST,"SEARCH_500","기록 검색 에러입니다."),
     SEARCH_MEMBER_ERROR(HttpStatus.BAD_REQUEST,"SEARCH_500","유저 검색 에러입니다."),
-    SEARCH_FILTER_ERROR(HttpStatus.BAD_REQUEST,"SEARCH_4005","검색 필터가 유효하지 않습니다."),
-    SEARCHING_IOEXCEPION(HttpStatus.BAD_REQUEST,"SEARCH_4006","입출력 오류입니다."),
+    SEARCH_FILTER_ERROR(HttpStatus.BAD_REQUEST,"SEARCH_4002","검색 필터가 유효하지 않습니다."),
+    SEARCHING_IOEXCEPION(HttpStatus.BAD_REQUEST,"SEARCH_4003","입출력 오류입니다."),
+    ELASTIC_SEARCH_SYNC_FAULT(HttpStatus.BAD_REQUEST,"SEARCH_4004","엘라스틱 서치 동기화 오류입니다."),
+    ELASTIC_SEARCH_DELETE_FAULT(HttpStatus.BAD_REQUEST,"SEARCH_4005","엘라스틱 서치 삭제 오류입니다."),
 
     //홈 에러
     NO_SUCH_SECTION(HttpStatus.NOT_FOUND,"HOME_4041","해당 섹션이 존재하지 않습니다."),


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #185 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
JPA 엔티티와 ES 동기화 로직 구현했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 검색과 동기화를 위한 메소드를 SearchService와 SearchRepositoryService로 각각 분리하였습니다.
- 옷, 기록, 멤버의 생성/수정/삭제시 ES와 동기화 메소드를 작성 후 각각의 서비스단에 적용하였습니다.

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
회원 탈퇴시 ES와 동기화하는 메소드는 작성되었으나 회원 탈퇴부분이 개발되지 않아서 개발만 되면 붙여주면 됩니다.

이 외에 또 데이터가 변경되는데 적용이 안된 부분이 있다면 말씀해주세요!!