### PR TITLE
[refactor/#209] Redis 캐시 로직 수정

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryService.java
@@ -23,7 +23,7 @@ public interface HashtagHistoryRepositoryService {
 
     List<String> findHashtagNamesByHistoryId(Long historyId);
 
-    List<Long> findTop3HashtagIdsByMemberIdOrderByHistoryDateDesc(Long memberId);
+    List<Long> findHashtagIdsByMemberIdOrderByHistoryDateDesc(Long memberId);
 
     String findLatestTaggedHashtag(Long memberId);
 

--- a/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HashtagHistoryRepositoryServiceImpl.java
@@ -62,8 +62,8 @@ public class HashtagHistoryRepositoryServiceImpl implements HashtagHistoryReposi
     }
 
     @Override
-    public List<Long> findTop3HashtagIdsByMemberIdOrderByHistoryDateDesc(Long memberId) {
-        return hashtagHistoryRepository.findTop3HashtagIdsByMemberIdOrderByHistoryDateDesc(memberId);
+    public List<Long> findHashtagIdsByMemberIdOrderByHistoryDateDesc(Long memberId) {
+        return hashtagHistoryRepository.findHashtagIdsByMemberIdOrderByHistoryDateDesc(memberId);
     }
 
     @Override

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagHistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HashtagHistoryRepository.java
@@ -37,8 +37,8 @@ public interface HashtagHistoryRepository extends JpaRepository<HashtagHistory, 
             "JOIN hh.history h " +
             "WHERE h.member.id = :memberId " +
             "ORDER BY h.historyDate DESC " +
-            "LIMIT 3")
-    List<Long> findTop3HashtagIdsByMemberIdOrderByHistoryDateDesc(@Param("memberId") Long memberId);
+            "LIMIT 10")
+    List<Long> findHashtagIdsByMemberIdOrderByHistoryDateDesc(@Param("memberId") Long memberId);
 
 
     @Query("SELECT hh.hashtag.name FROM HashtagHistory hh " +

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
@@ -110,10 +110,10 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     @Override
     public RecommendationResponseDTO.DailyNewsResult getNews(Long memberId) {
-        String cacheKeyRecommend = REDIS_PREFIX_RECOMMEND + memberId + ":" + LocalDate.now();
-        String cacheKeyCloset = REDIS_PREFIX_CLOSET + memberId + ":" + LocalDate.now();
-        String cacheKeyCalendar = REDIS_PREFIX_CALENDAR + memberId + ":" + LocalDate.now();
-        String cacheKeyPeople = REDIS_PREFIX_PEOPLE + memberId + ":" + LocalDate.now();
+        String cacheKeyRecommend = REDIS_PREFIX_RECOMMEND + memberId + ":";
+        String cacheKeyCloset = REDIS_PREFIX_CLOSET + memberId + ":";
+        String cacheKeyCalendar = REDIS_PREFIX_CALENDAR + memberId + ":";
+        String cacheKeyPeople = REDIS_PREFIX_PEOPLE + memberId + ":";
 
         RecommendationResponseDTO.DailyResult<?> recommendResult = getFromRedis(cacheKeyRecommend, RecommendationResponseDTO.DailyResult.class);
         RecommendationResponseDTO.DailyResult<?> closetResult = getFromRedis(cacheKeyCloset, RecommendationResponseDTO.DailyResult.class);

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
@@ -110,10 +110,10 @@ public class RecommendationServiceImpl implements RecommendationService {
 
     @Override
     public RecommendationResponseDTO.DailyNewsResult getNews(Long memberId) {
-        String cacheKeyRecommend = REDIS_PREFIX_RECOMMEND + memberId + ":";
-        String cacheKeyCloset = REDIS_PREFIX_CLOSET + memberId + ":";
-        String cacheKeyCalendar = REDIS_PREFIX_CALENDAR + memberId + ":";
-        String cacheKeyPeople = REDIS_PREFIX_PEOPLE + memberId + ":";
+        String cacheKeyRecommend = REDIS_PREFIX_RECOMMEND + memberId;
+        String cacheKeyCloset = REDIS_PREFIX_CLOSET + memberId;
+        String cacheKeyCalendar = REDIS_PREFIX_CALENDAR + memberId;
+        String cacheKeyPeople = REDIS_PREFIX_PEOPLE + memberId;
 
         RecommendationResponseDTO.DailyResult<?> recommendResult = getFromRedis(cacheKeyRecommend, RecommendationResponseDTO.DailyResult.class);
         RecommendationResponseDTO.DailyResult<?> closetResult = getFromRedis(cacheKeyCloset, RecommendationResponseDTO.DailyResult.class);
@@ -284,7 +284,7 @@ public class RecommendationServiceImpl implements RecommendationService {
     // Hot 계정 조회
     private List<RecommendationResponseDTO.People> getPeopleList(Member member) {
         //기록 최신 것부터 해시태그를 조회함. 해시태그 아이디를 hashtagHistoryRepository에서 찾아서 그 history의 주인들을 최대 네 명 추천해주는 로직.
-        List<Long> hashtagIds = hashtagHistoryRepositoryService.findTop3HashtagIdsByMemberIdOrderByHistoryDateDesc(member.getId());
+        List<Long> hashtagIds = hashtagHistoryRepositoryService.findHashtagIdsByMemberIdOrderByHistoryDateDesc(member.getId());
 
         if (hashtagIds.isEmpty()) {
             return List.of(); // 해시태그가 없으면 빈 리스트 반환
@@ -314,15 +314,6 @@ public class RecommendationServiceImpl implements RecommendationService {
 
         // 중복 제거 및 최대 4명 추천
         return RecommendationConverter.toPeopleDTO(filteredHistories, historyImageMap);
-    }
-
-    private Recommendation createDefaultRecommend(Long memberId, NewsType type) {
-        Member member = memberRepositoryService.findMemberById(memberId);
-
-        return Recommendation.builder()
-                .newsType(type)
-                .member(member)
-                .build();
     }
 
     private List<Member> getFollowingMembers(Long memberId){

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
@@ -231,7 +231,10 @@ public class RecommendationServiceImpl implements RecommendationService {
                 ));
 
         // 그룹화된 데이터를 `Closet` DTO로 변환
-        return RecommendationConverter.toClosetDTO(groupedClothes);
+        return groupedClothes.entrySet().stream()
+                .max(Comparator.comparing(entry -> entry.getKey().getSecond()))
+                .map(entry -> RecommendationConverter.toClosetDTO(Map.of(entry.getKey(), entry.getValue())))
+                .orElse(List.of());
     }
 
     private Page<RecommendationResponseDTO.Closet> getClosetPage(int page, List<Member> followingMembers) {

--- a/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
@@ -117,7 +117,7 @@ public class RecommendationConverter {
                 .build();
     }
 
-    public static RecommendationResponseDTO.DailyNewsResult toDailyNewsResult(List<RecommendationResponseDTO.Recommend> recommendList, List<RecommendationResponseDTO.Closet> closetList, List<RecommendationResponseDTO.Calendar> calendarList, List<RecommendationResponseDTO.People> peopleList) {
+    public static RecommendationResponseDTO.DailyNewsResult toDailyNewsResult(RecommendationResponseDTO.DailyResult<?> recommendList, RecommendationResponseDTO.DailyResult<?> closetList, RecommendationResponseDTO.DailyResult<?> calendarList, RecommendationResponseDTO.DailyResult<?> peopleList) {
         return RecommendationResponseDTO.DailyNewsResult.builder()
                 .recommend(recommendList)
                 .closet(closetList)
@@ -132,6 +132,12 @@ public class RecommendationConverter {
                 .nickName(member.getNickname())
                 .imageUrls(historyImageUrls)
                 .isMine(isMine)
+                .build();
+    }
+
+    public static RecommendationResponseDTO.DailyResult<?> toDailyResult(List<?> results){
+        return RecommendationResponseDTO.DailyResult.builder()
+                .innerResult((List<Object>) results)
                 .build();
     }
 }

--- a/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
@@ -94,7 +94,7 @@ public class RecommendationConverter {
                 .build();
     }
 
-    public static RecommendationResponseDTO.DailyNewsResult toDailyNewsResult(RecommendationResponseDTO.DailyResult<?> recommendList, RecommendationResponseDTO.DailyResult<?> closetList, RecommendationResponseDTO.DailyResult<?> calendarList, RecommendationResponseDTO.DailyResult<?> peopleList) {
+    public static RecommendationResponseDTO.DailyNewsResult toDailyNewsResult(List<RecommendationResponseDTO.Recommend> recommendList, List<RecommendationResponseDTO.Closet> closetList, List<RecommendationResponseDTO.Calendar> calendarList, List<RecommendationResponseDTO.People> peopleList) {
         return RecommendationResponseDTO.DailyNewsResult.builder()
                 .recommend(recommendList)
                 .closet(closetList)
@@ -109,12 +109,6 @@ public class RecommendationConverter {
                 .nickName(member.getNickname())
                 .imageUrls(historyImageUrls)
                 .isMine(isMine)
-                .build();
-    }
-
-    public static RecommendationResponseDTO.DailyResult<?> toDailyResult(List<?> results){
-        return RecommendationResponseDTO.DailyResult.builder()
-                .innerResult((List<Object>) results)
                 .build();
     }
 }

--- a/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.checkerframework.checker.units.qual.C;
 
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -36,19 +37,10 @@ public class RecommendationResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DailyNewsResult {
-        private DailyResult<?> recommend;
-        private DailyResult<?> closet;
-        private DailyResult<?> calendar;
-        private DailyResult<?> people;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class DailyResult<T> implements Serializable {
-        private static final long serialVersionUID = 1L;
-        private List<T> innerResult;
+        private List<Recommend> recommend;
+        private List<Closet> closet;
+        private List<Calendar> calendar;
+        private List<People> people;
     }
 
     @Builder

--- a/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
@@ -94,14 +94,6 @@ public class RecommendationResponseDTO {
         private LocalDate date;
         private String clokeyId;
         private String profileImage;
-        private List<Event> events;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Event {
         private Long historyId;
         private String imageUrl;
     }

--- a/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
@@ -35,13 +35,20 @@ public class RecommendationResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
-    public static class DailyNewsResult implements Serializable {
+    public static class DailyNewsResult {
+        private DailyResult<?> recommend;
+        private DailyResult<?> closet;
+        private DailyResult<?> calendar;
+        private DailyResult<?> people;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DailyResult<T> implements Serializable {
         private static final long serialVersionUID = 1L;
-        private List<Recommend> recommend;
-        private List<Closet> closet;
-        private List<Calendar> calendar;
-        private List<People> people;
+        private List<T> innerResult;
     }
 
     @Builder

--- a/src/main/java/com/clokey/server/global/infra/redis/RedisService.java
+++ b/src/main/java/com/clokey/server/global/infra/redis/RedisService.java
@@ -1,4 +1,4 @@
-package com.clokey.server.domain;
+package com.clokey.server.global.infra.redis;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/com/clokey/server/domain/RedisServiceTest.java
+++ b/src/test/java/com/clokey/server/domain/RedisServiceTest.java
@@ -1,16 +1,13 @@
 package com.clokey.server.domain;
 
-import org.assertj.core.api.Assertions;
+import com.clokey.server.global.infra.redis.RedisService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #209 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 기존에 전체 다 저장하는 로직을 각각 캐시 기간을 다르게 하여 저장하도록 수정하였습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 레디스 저장 함수와 레디스에서 가져오는 함수 구현하였습니다.
- 추천소식, 추천계정은 24시간이며, 팔로우 한 사람의 옷 업데이트, 기록 업데이트는 3시간입니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/f64e8f34-8c63-492b-a0b3-1b2cf1744d47)
![image](https://github.com/user-attachments/assets/e32e9db5-185e-4454-9b36-e450135a20e6)
![image](https://github.com/user-attachments/assets/f0c710df-3de5-4e7b-8fd4-1f3a3532cb63)

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
