### PR TITLE
[refactor/#216] 검색 로직 개선

### DIFF
--- a/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
@@ -192,19 +192,10 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
                 .collect(Collectors.toList());
 
         // Image URL 가져오기 (공개된 첫 번째 옷 이미지)
-        List<String> imageUrls = historyImageRepositoryService.findByHistoryId(history.getId()).stream()
+        String imageUrl = historyImageRepositoryService.findByHistoryId(history.getId()).stream()
                 .sorted(Comparator.comparing(HistoryImage::getCreatedAt))
                 .map(HistoryImage::getImageUrl)
-                .toList();
-
-        // 첫 번째 이미지 선택 (없다면 대체 이미지 가져오기)
-        String imageUrl = imageUrls.isEmpty()
-                ? historyClothRepositoryService.findAllClothByHistoryId(history.getId()).stream()
-                .filter(cloth -> !cloth.getVisibility().equals(Visibility.PRIVATE))
-                .findFirst()
-                .map(cloth -> cloth.getImage() != null ? cloth.getImage().getImageUrl() : null)
-                .orElse("null")
-                : imageUrls.get(0);
+                .toList().get(0);
 
         // Elasticsearch 문서 변환
         BulkOperation bulkOperation = BulkOperation.of(op -> op

--- a/src/main/java/com/clokey/server/domain/search/application/SearchServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchServiceImpl.java
@@ -90,10 +90,18 @@ public class SearchServiceImpl implements SearchService {
                                             .query(keyword)
                                             .fuzziness("AUTO")
                                     ))
+                                    .should(ms -> ms.matchPhrasePrefix(mq -> mq
+                                            .field("name")
+                                            .query(keyword)
+                                    ))
                                     .should(ms -> ms.match(mq -> mq
                                             .field("brand")
                                             .query(keyword)
                                             .fuzziness("AUTO")
+                                    ))
+                                    .should(ms -> ms.matchPhrasePrefix(mq -> mq
+                                            .field("brand")
+                                            .query(keyword)
                                     ))
                             ));
                             return b;
@@ -160,6 +168,10 @@ public class SearchServiceImpl implements SearchService {
                             ));
                             // 카테고리 아우터만 검색해도 "아우터/무스탕" 검색되도록 설정
                             b.must(m -> m.matchBoolPrefix(t -> t
+                                    .field("categoryNames")
+                                    .query(keyword)
+                            ));
+                            b.must(m -> m.matchPhrasePrefix(t -> t
                                     .field("categoryNames")
                                     .query(keyword)
                             ));

--- a/src/main/resources/static/elastic-mapping.json
+++ b/src/main/resources/static/elastic-mapping.json
@@ -1,48 +1,51 @@
 {
-  "properties": {
-    "nickname": {
-      "type": "text",
-      "analyzer": "nori_analyzer"
-    },
-    "clokeyId": {
-      "type": "text",
-      "analyzer": "nori_analyzer"
-    },
-    "name": {
-      "type": "text",
-      "analyzer": "nori_analyzer"
-    },
-    "brand": {
-      "type": "text",
-      "analyzer": "nori_analyzer"
-    },
-    "hashtagNames": {
-      "type": "text",
-      "analyzer": "nori_analyzer"
-    },
-    "categoryNames": {
-      "type": "text",
-      "analyzer": "nori_analyzer"
-    },
-    "imageUrl": {
-      "type": "text",
-      "index": false
-    },
-    "wearNum": {
-      "type": "integer",
-      "index": false
-    },
-    "memberId": {
-      "type": "long"
-    },
-    "visibility": {
-      "type": "keyword"
-    },
-    "memberVisibility": {
-      "type": "keyword"
-    },
-    "historyVisibility": {
-      "type": "keyword"
+  "mappings": {
+    "properties": {
+      "nickname": {
+        "type": "text",
+        "analyzer": "nori_analyzer"
+      },
+      "clokeyId": {
+        "type": "text",
+        "analyzer": "clokeyId_analyzer",
+        "search_analyzer": "clokeyId_analyzer"
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "nori_analyzer"
+      },
+      "brand": {
+        "type": "text",
+        "analyzer": "nori_analyzer"
+      },
+      "hashtagNames": {
+        "type": "text",
+        "analyzer": "nori_analyzer"
+      },
+      "categoryNames": {
+        "type": "text",
+        "analyzer": "nori_analyzer"
+      },
+      "imageUrl": {
+        "type": "text",
+        "index": false
+      },
+      "wearNum": {
+        "type": "integer",
+        "index": false
+      },
+      "memberId": {
+        "type": "long"
+      },
+      "visibility": {
+        "type": "keyword"
+      },
+      "memberVisibility": {
+        "type": "keyword"
+      },
+      "historyVisibility": {
+        "type": "keyword"
+      }
     }
   }
 }

--- a/src/main/resources/static/elastic-setting.json
+++ b/src/main/resources/static/elastic-setting.json
@@ -1,10 +1,30 @@
 {
-  "analysis": {
-    "analyzer": {
-      "nori_analyzer": {
-        "type": "custom",
-        "tokenizer": "nori_tokenizer",
-        "filter": ["lowercase"]
+  "settings": {
+    "analysis": {
+      "char_filter": {
+        "remove_special_chars": {
+          "type": "pattern_replace",
+          "pattern": "[._]",
+          "replacement": ""
+        }
+      },
+      "filter": {
+        "nori_readingform_filter": {
+          "type": "nori_readingform"
+        }
+      },
+      "analyzer": {
+        "nori_analyzer": {
+          "type": "custom",
+          "tokenizer": "nori_tokenizer",
+          "filter": ["lowercase"]
+        },
+        "clokeyId_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "char_filter": ["remove_special_chars"],
+          "filter": ["lowercase", "nori_readingform_filter"]
+        }
       }
     }
   }

--- a/src/main/resources/static/elastic-setting.json
+++ b/src/main/resources/static/elastic-setting.json
@@ -17,13 +17,20 @@
         "nori_analyzer": {
           "type": "custom",
           "tokenizer": "nori_tokenizer",
-          "filter": ["lowercase"]
+          "filter": [
+            "lowercase"
+          ]
         },
         "clokeyId_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": ["remove_special_chars"],
-          "filter": ["lowercase", "nori_readingform_filter"]
+          "char_filter": [
+            "remove_special_chars"
+          ],
+          "filter": [
+            "lowercase",
+            "nori_readingform_filter"
+          ]
         }
       }
     }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #216

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
검색 로직 개선을 진행했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 옷 검색 개선 사항
이름에 matchBoolPrefix 적용: 옷 이름은 포함만 되면 검색
브랜드에 match 적용: 브랜드는 어느정도 일치하면 검색

- 기록 검색 개선 사항
해시태그와 카테고리에 multiMatch 적용: 해시태그와 카테고리로 부분 검색 가능 및 오타 허용
해시태그에 matchBoolPrefix: 해시태그 내용이 포함만 되면 검색
해시태그에 matchPhrasePrefix: 해시태그 검색어로 시작되면 검색
해시태그에 wildcard: 해시태그 포함만 하면 되도록 유연한 검색
카테고리에 matchBoolPrefix: 카테고리 포함만 하면 검색
(여러 필터 적용시 검색 범위 늘어나는 설계임)

- 계정 검색 개선 사항
 닉네임과 클로키아이디에 multi_match: 닉네임과 clokeyId에서 부분 검색 가능하며, 오타(fuzziness: "AUTO")도 허용
 닉네임에 match_bool_prefix: 입력한 단어가 포함된 모든 데이터로 닉네임 검색
 클로키아이디에 matchPhrasePrefix: 입력한 단어로 시작하는 모든 데이터로 clokeyId 검색

- ClokeyId 검색 시, 한영 발음 변환기 필터(korean_to_latin) 및 특수문자 제거 필터 (char_filter) 적용

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
- 한영 발음 변환 필터 적용
![image](https://github.com/user-attachments/assets/13dc9b13-3d7a-430a-939c-93076c8c4d46)
![image](https://github.com/user-attachments/assets/723187f4-aa8a-47c1-98f7-ea42b3a9d531)

- 특수문자 제거 필터 적용
![image](https://github.com/user-attachments/assets/c6390e79-25a8-47f3-b63c-f13dd6045ebe)
![image](https://github.com/user-attachments/assets/ed519405-f633-4c1f-a7bf-ab32f64795d4)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
잘되네욤 ㅎㅎ

최종 로직은 아래와 같습니다.

아래의 로직이 or 처리되어서 그 중에 가장 일치하는 데이터들을 불러옵니다.

- 계정 검색
닉네임,클로키아이디 -> best 검색
닉네임 -> 포함 완전 검색
클로키아이디 -> 시작 검색

- 기록 검색
해시태그, 카테고리 -> best 검색
해시태그 -> 일치 검색, 포함 완전 검색, 시작 검색
카테고리 -> 포함 검색, 시작 검색

- 옷 검색
이름 -> best 검색, 포함 검색, 시작 검색
브랜드 -> best 검색, 시작 검색