### PR TITLE
[fix/#225] 해시태그 검색 로직 개선

### DIFF
--- a/src/main/java/com/clokey/server/domain/search/application/SearchServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchServiceImpl.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.naming.SelectorContext.prefix;
+
 @Service
 @RequiredArgsConstructor
 public class SearchServiceImpl implements SearchService {
@@ -123,20 +125,18 @@ public class SearchServiceImpl implements SearchService {
 
                             // 해시태그 및 카테고리 검색
                             b.must(m -> m.bool(bb -> bb
-                                    // 해시태그가 검색어와 완전히 일치하는 경우
-                                    .should(ms -> ms.term(mq -> mq
+                                    .must(ms -> ms.wildcard(mq -> mq
                                             .field("hashtagNames.keyword")
-                                            .value(keyword)
+                                            .value("#" + keyword + "*")
                                     ))
-                                    // 검색어로 시작하는 해시태그만 반환 (prefix 사용)
-                                    .should(ms -> ms.prefix(mq -> mq
-                                            .field("hashtagNames.keyword")
-                                            .value(keyword)
+                                    .should(ms -> ms.match(mq -> mq
+                                            .field("hashtagNames")
+                                            .query(keyword)
+                                            .fuzziness("AUTO")
                                     ))
-                                    // 검색어로 시작하는 해시태그만 반환 (wildcard 사용)
-                                    .should(ms -> ms.wildcard(mq -> mq
-                                            .field("hashtagNames.keyword")
-                                            .value(keyword + "*")
+                                    .should(ms -> ms.matchPhrasePrefix(mq -> mq
+                                            .field("hashtagNames")
+                                            .query(keyword)
                                     ))
                                     .should(ms -> ms.matchPhrasePrefix(mq -> mq
                                             .field("categoryNames")


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 해시태그 #을 무조건 포함한다고 가정한 로직을 추가하여 검색 정확도를 높였습니다.
