### PR TITLE
[refactor/#285] history 기능 리펙토링 및 수정 사항 반영

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -45,4 +45,6 @@ public interface HistoryRepositoryService {
     Long countHistoryByMember(Member member);
 
     List<History> findHistoriesByMemberIds(List<Long> memberIds);
+
+    List<History> findHistoriesByMemberIdsAndDateRange(List<Long> memberIds, LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
@@ -107,4 +107,9 @@ public class HistoryRepositoryServiceImpl implements HistoryRepositoryService {
     public List<History> findHistoriesByMemberIds(List<Long> memberIds) {
         return historyRepository.findHistoryByMemberIdIn(memberIds);
     }
+
+    @Override
+    public List<History> findHistoriesByMemberIdsAndDateRange(List<Long> memberIds, LocalDate from, LocalDate to) {
+        return historyRepository.findHistoriesByMemberIdsAndDateRange(memberIds, from, to);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
+++ b/src/main/java/com/clokey/server/domain/history/converter/HistoryConverter.java
@@ -115,7 +115,10 @@ public class HistoryConverter {
         return HistoryResponseDTO.HistoryCommentResult.builder()
                 .comments(toCommentResultList(comments, replies))
                 .totalPage(comments.getTotalPages())
-                .totalElements(comments.getNumberOfElements())
+                .totalElements(comments.getNumberOfElements()
+                        + replies.stream()
+                        .mapToInt(List::size)
+                        .sum())
                 .isFirst(comments.isFirst())
                 .isLast(comments.isLast())
                 .build();

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -77,4 +77,11 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
             "AND h.createdAt = (SELECT MAX(h2.createdAt) FROM History h2 WHERE h2.member.id = h.member.id)")
     List<History> findHistoryByMemberIdIn(@Param("memberIds") List<Long> memberIds);
 
+    @Query("SELECT h FROM History h WHERE h.member.id IN :memberIds " +
+            "AND h.historyDate BETWEEN :from AND :to")
+    List<History> findHistoriesByMemberIdsAndDateRange(
+            @Param("memberIds") List<Long> memberIds,
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to);
+
 }

--- a/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
@@ -99,7 +99,7 @@ public class MemberRestController {
     @Operation(summary = "본인 확인 API", description = "clokeyId를 기반으로 본인인지 확인.")
     @GetMapping("users/checkMyself")
     public BaseResponse<MemberDTO.checkMyselfResult> checkMyself(@Parameter(name = "user", hidden = true) @AuthUser Member member,
-                                                                      @PathVariable("clokeyId") @IdValid String clokeyId) {
+                                                                 @Parameter(name = "clokeyId", description = "본인인지 확인하고 싶은 clokeyId") @IdValid String clokeyId) {
         MemberDTO.checkMyselfResult response = memberService.checkMyself(member.getClokeyId(),clokeyId);
         return BaseResponse.onSuccess(SuccessStatus.MEMBER_SUCCESS, response);
     }

--- a/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
@@ -95,4 +95,12 @@ public class MemberRestController {
         MemberDTO.GetFollowMemberResult response = memberService.getFollowPeople(member.getId(), clokeyId, page, isFollowing);
         return BaseResponse.onSuccess(SuccessStatus.MEMBER_SUCCESS, response);
     }
+
+    @Operation(summary = "본인 확인 API", description = "clokeyId를 기반으로 본인인지 확인.")
+    @GetMapping("users/checkMyself")
+    public BaseResponse<MemberDTO.checkMyselfResult> checkMyself(@Parameter(name = "user", hidden = true) @AuthUser Member member,
+                                                                      @PathVariable("clokeyId") @IdValid String clokeyId) {
+        MemberDTO.checkMyselfResult response = memberService.checkMyself(member.getClokeyId(),clokeyId);
+        return BaseResponse.onSuccess(SuccessStatus.MEMBER_SUCCESS, response);
+    }
 }

--- a/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
@@ -97,7 +97,7 @@ public class MemberRestController {
     }
 
     @Operation(summary = "본인 확인 API", description = "clokeyId를 기반으로 본인인지 확인.")
-    @GetMapping("users/checkMyself")
+    @GetMapping("users/check-myself")
     public BaseResponse<MemberDTO.checkMyselfResult> checkMyself(@Parameter(name = "user", hidden = true) @AuthUser Member member,
                                                                  @Parameter(name = "clokeyId", description = "본인인지 확인하고 싶은 clokeyId") @IdValid String clokeyId) {
         MemberDTO.checkMyselfResult response = memberService.checkMyself(member.getClokeyId(),clokeyId);

--- a/src/main/java/com/clokey/server/domain/member/application/MemberService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberService.java
@@ -20,4 +20,5 @@ public interface MemberService {
 
     MemberDTO.GetFollowMemberResult getFollowPeople(Long memberId, String clokeyId, Integer page, Boolean isFollow);
 
+    MemberDTO.checkMyselfResult checkMyself(String myClokeyId, String checkClokeyId);
 }

--- a/src/main/java/com/clokey/server/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberServiceImpl.java
@@ -210,4 +210,9 @@ public class MemberServiceImpl implements MemberService {
         return GetUserConverter.toGetFollowPeopleResultDTO(new ArrayList<>(), pageable, new ArrayList<>(), new ArrayList<>());
     }
 
+    @Override
+    public MemberDTO.checkMyselfResult checkMyself(String myClokeyId, String checkClokeyId) {
+        return GetUserConverter.toCheckMyselfResult(myClokeyId.equals(checkClokeyId));
+    }
+
 }

--- a/src/main/java/com/clokey/server/domain/member/converter/GetUserConverter.java
+++ b/src/main/java/com/clokey/server/domain/member/converter/GetUserConverter.java
@@ -30,6 +30,12 @@ public class GetUserConverter {
                 .build();
     }
 
+    public static MemberDTO.checkMyselfResult toCheckMyselfResult(Boolean isMe){
+        return MemberDTO.checkMyselfResult.builder()
+                .isMe(isMe)
+                .build();
+    }
+
     public static List<MemberDTO.GetUserClothResult> toGetUserClothResultDTO(List<Cloth> cloths) {
         return cloths.stream()
                 .map(cloth -> {

--- a/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/clokey/server/domain/member/dto/MemberDTO.java
@@ -124,4 +124,13 @@ public class MemberDTO {
         Boolean isFollowed;
         Boolean isMe;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class checkMyselfResult {
+        Boolean isMe;
+    }
+
 }

--- a/src/main/java/com/clokey/server/domain/notification/application/NotificationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/notification/application/NotificationServiceImpl.java
@@ -198,7 +198,7 @@ public class NotificationServiceImpl implements NotificationService {
 
 
     private void checkFollowing(Long followingId, Long followedId) {
-        if (followRepositoryService.existsByFollowing_IdAndFollowed_Id(followingId, followedId)) {
+        if (!followRepositoryService.existsByFollowing_IdAndFollowed_Id(followingId, followedId)) {
             throw new NotificationException(ErrorStatus.NOTIFICATION_NOT_FOLLOWING);
         }
     }

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
@@ -375,6 +375,7 @@ public class RecommendationServiceImpl implements RecommendationService {
         }
 
         List<Long> followingMembers = followRepositoryService.findFollowingByFollowedId(memberId).stream()
+                .filter(member1 -> member1.getVisibility().equals(Visibility.PUBLIC))
                 .map(Member::getId)
                 .toList();
 

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
@@ -366,32 +366,47 @@ public class RecommendationServiceImpl implements RecommendationService {
         LocalDate today = LocalDate.now();
         LocalDate oneYearAgo = today.minusYears(1);
 
+        //자신의 1년전 기록을 탐색합니다.
         if (historyRepositoryService.checkHistoryExistOfDate(oneYearAgo, memberId)) {
-            Long historyOneYearAgoId = historyRepositoryService.getHistoryOfDate(oneYearAgo, memberId).getId();
-            List<String> historyUrls = historyImageRepositoryService.findByHistoryId(historyOneYearAgoId).stream()
+            History historyOneYearAgo = historyRepositoryService.getHistoryOfDate(oneYearAgo, memberId);
+            List<String> historyUrls = historyImageRepositoryService.findByHistoryId(historyOneYearAgo.getId()).stream()
                     .map(HistoryImage::getImageUrl)
                     .toList();
-            return RecommendationConverter.toLastYearHistoryResult(historyOneYearAgoId, historyUrls, member, true);
+            return RecommendationConverter.toLastYearHistoryResult(historyOneYearAgo.getId(), historyOneYearAgo.getHistoryDate(), historyUrls, member, true);
         }
 
         List<Long> followingMembers = followRepositoryService.findFollowingByFollowedId(memberId).stream()
                 .filter(member1 -> member1.getVisibility().equals(Visibility.PUBLIC))
                 .map(Member::getId)
-                .toList();
+                .collect(Collectors.toList());
 
         List<Boolean> membersHaveHistoryOneYearAgo = historyRepositoryService.existsByHistoryDateAndMemberIds(oneYearAgo, followingMembers);
 
         Long memberPicked = getRandomMemberWithHistory(followingMembers, membersHaveHistoryOneYearAgo);
 
+        // 팔로우 하는 사람들의 1년전 오늘을 확인합니다.
         if (memberPicked != null) {
-            Long historyOneYearAgoId = historyRepositoryService.getHistoryOfDate(oneYearAgo, memberPicked).getId();
-            List<String> historyUrls = historyImageRepositoryService.findByHistoryId(historyOneYearAgoId).stream()
+            History historyOneYearAgo = historyRepositoryService.getHistoryOfDate(oneYearAgo, memberPicked);
+            List<String> historyUrls = historyImageRepositoryService.findByHistoryId(historyOneYearAgo.getId()).stream()
                     .map(HistoryImage::getImageUrl)
                     .toList();
-            return RecommendationConverter.toLastYearHistoryResult(historyOneYearAgoId, historyUrls, member, false);
+            return RecommendationConverter.toLastYearHistoryResult(historyOneYearAgo.getId(),historyOneYearAgo.getHistoryDate(), historyUrls, memberRepositoryService.findMemberById(memberPicked), false);
         }
 
-        return RecommendationConverter.toLastYearHistoryResult(null, null, member, true);
+        // 나와 팔로우 하는 사람들의 랜덤 게시물을 반환합니다.
+        List<Long> members = new ArrayList<>(followingMembers);
+        members.add(memberId);
+        List<History> histories = historyRepositoryService.findHistoriesByMemberIdsAndDateRange(members,oneYearAgo,today);
+        if(histories != null && !histories.isEmpty()){
+            History randomHistory = histories.get(new Random().nextInt(histories.size()));
+            List<String> historyUrls = historyImageRepositoryService.findByHistoryId(randomHistory.getId()).stream()
+                    .map(HistoryImage::getImageUrl)
+                    .toList();
+            return RecommendationConverter.toLastYearHistoryResult(randomHistory.getId(),randomHistory.getHistoryDate(),historyUrls,randomHistory.getMember(), randomHistory.getMember().equals(member));
+        }
+
+
+        return RecommendationConverter.toLastYearHistoryResult(null, null, null, member, true);
     }
 
     private Long getRandomMemberWithHistory(List<Long> followingMembers, List<Boolean> membersHaveHistoryOneYearAgo) {

--- a/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/converter/RecommendationConverter.java
@@ -154,9 +154,10 @@ public class RecommendationConverter {
                 .build();
     }
 
-    public static RecommendationResponseDTO.LastYearHistoryResult toLastYearHistoryResult(Long historyId, List<String> historyImageUrls, Member member, Boolean isMine) {
+    public static RecommendationResponseDTO.LastYearHistoryResult toLastYearHistoryResult(Long historyId, LocalDate date, List<String> historyImageUrls, Member member, Boolean isMine) {
         return RecommendationResponseDTO.LastYearHistoryResult.builder()
                 .historyId(historyId)
+                .date(date)
                 .nickName(member.getNickname())
                 .imageUrls(historyImageUrls)
                 .isMine(isMine)

--- a/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/dto/RecommendationResponseDTO.java
@@ -145,6 +145,7 @@ public class RecommendationResponseDTO {
         Boolean isMine;
         Long historyId;
         String nickName;
+        LocalDate date;
         List<String> imageUrls;
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #285 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- clokeyId 기반으로 자신인지 확인할 수 있는 매서드를 추가했습니다.
- 기록의 댓글을 조회시 totalElements는 이제 대댓글의 개수까지 포함합니다.
- 1년전 오늘 기록의 로직에서 비공개 사용자는 반환하지 않도록 수정되었습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 본인확인 매서드 추가
<img width="538" alt="스크린샷 2025-03-01 오전 1 43 50" src="https://github.com/user-attachments/assets/dfba97bc-3ba1-4e3e-a94b-cdcdef47aa50" />
<img width="1064" alt="스크린샷 2025-03-01 오전 1 03 57" src="https://github.com/user-attachments/assets/dbd1dc8a-f2d6-469d-90a7-afe341380f0b" />

-기록의 댓글을 조회시 totalElements는 이제 대댓글의 개수까지 포함합니다. 
-1년전 오늘 기록의 로직에서 비공개 사용자는 반환하지 않도록 수정되었습니다.
-1년전 오늘의 로직이 변경되었습니다.
1 순위: 1년전 나의 기록
2 순위 : 팔로우 하는 사람들의 1년전 기록
3 순위 : 1년전과 오늘 사이의 랜덤 기록(나와 팔로워들의)

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
