### PR TITLE
[refactor/#310] 스마트 요약 및 옷장 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
+++ b/src/main/java/com/clokey/server/domain/cloth/api/ClothRestController.java
@@ -45,7 +45,7 @@ public class ClothRestController {
 
     // 스마트 요약 API
     @GetMapping("/smart-summary")
-    @Operation(summary = "일주일간 평균 착용 횟수에 따른 스마트 요약 API", description = "query string으로 SummaryFrequency를 넘겨주세요")
+    @Operation(summary = "한달 간 평균 착용 횟수에 따른 스마트 요약 API", description = "query string으로 SummaryFrequency를 넘겨주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CLOTH_200", description = "OK, 성공적으로 조회되었습니다."),
     })
@@ -78,7 +78,7 @@ public class ClothRestController {
             @Parameter(name = "page", description = "페이지 값, query string 입니다."),
             @Parameter(name = "size", description = "페이지에 표시할 요소 개수 값, query string 입니다.")
     })
-    public BaseResponse<ClothResponseDTO.ClothPreviewListResult> getClothPreviewInfoListByCategoryId(
+    public BaseResponse<ClothResponseDTO.ClosetViewResult> getClothPreviewInfoListByCategoryId(
             @RequestParam(value = "clokeyId", required = false) @NullableClokeyIdExist String clokeyId,
             @RequestParam @CategoryExist Long categoryId,
             @RequestParam Season season,
@@ -94,7 +94,7 @@ public class ClothRestController {
             // 조회하는 유저와 다른 유저의 옷장이고, 그 유저가 비공개인 유저인지 확인합니다.
             memberAccessibleValidator.validateClothAccessOfMember(clokeyId, member.getId());
         }
-        ClothResponseDTO.ClothPreviewListResult result = clothService.readClothPreviewInfoListByClokeyId(clokeyId, member.getId(), categoryId, season, sort, page, size);
+        ClothResponseDTO.ClosetViewResult result = clothService.readClothPreviewInfoListByClokeyId(clokeyId, member.getId(), categoryId, season, sort, page, size);
 
         return BaseResponse.onSuccess(SuccessStatus.CLOTH_SUCCESS, result);
     }

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothImageRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothImageRepositoryService.java
@@ -6,6 +6,8 @@ import com.clokey.server.domain.cloth.domain.entity.ClothImage;
 
 public interface ClothImageRepositoryService {
 
+    ClothImage findByClothId(Long clothId);
+
     void save(ClothImage clothImage);
 
     void deleteByClothId(Long clothId);

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothImageRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothImageRepositoryServiceImpl.java
@@ -20,6 +20,9 @@ public class ClothImageRepositoryServiceImpl implements ClothImageRepositoryServ
     private final S3ImageService s3ImageService;
 
     @Override
+    public ClothImage findByClothId(Long clothId) { return clothImageRepository.findByClothId(clothId); }
+
+    @Override
     public void save(ClothImage clothImage) {
         clothImageRepository.save(clothImage);
     }

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothService.java
@@ -17,7 +17,7 @@ public interface ClothService {
 
     ClothResponseDTO.ClothDetailViewResult readClothDetailInfoById(Long clothId);
 
-    ClothResponseDTO.ClothPreviewListResult readClothPreviewInfoListByClokeyId(String ownerClokeyId, Long requesterId, Long categoryId, Season season, ClothSort sort, int page, int pageSize);
+    ClothResponseDTO.ClosetViewResult readClothPreviewInfoListByClokeyId(String ownerClokeyId, Long requesterId, Long categoryId, Season season, ClothSort sort, int page, int pageSize);
 
     ClothResponseDTO.SmartSummaryClothPreviewListResult readSmartSummary(Long memberId);
 

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothServiceImpl.java
@@ -50,6 +50,7 @@ public class ClothServiceImpl implements ClothService {
     private static final String FAILED_ES_UPDATE_SYNC_CLOTH_KEY = "failed_es_update_sync_cloth";
     private static final String FAILED_ES_DELETE_SYNC_CLOTH_KEY = "failed_es_delete_sync_cloth";
 
+    @Override
     @Transactional(readOnly = true)
     public ClothResponseDTO.ClothPopupViewResult readClothPopupInfoById(Long clothId) {
 
@@ -58,6 +59,7 @@ public class ClothServiceImpl implements ClothService {
         return ClothConverter.toClothPopupViewResult(cloth);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public ClothResponseDTO.ClothEditViewResult readClothEditInfoById(Long clothId){
 
@@ -66,6 +68,7 @@ public class ClothServiceImpl implements ClothService {
         return ClothConverter.toClothEditViewResult(cloth);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public ClothResponseDTO.ClothDetailViewResult readClothDetailInfoById(Long clothId){
 
@@ -75,6 +78,7 @@ public class ClothServiceImpl implements ClothService {
     }
 
     // 옷장의 옷의 PreView 조회 후 옷장 조회 DTO로 변환해서 반환
+    @Override
     @Transactional(readOnly = true)
     public ClothResponseDTO.ClosetViewResult readClothPreviewInfoListByClokeyId(
             String ownerClokeyId, Long requesterId, Long categoryId, Season season, ClothSort sort, int page, int size) {
@@ -92,6 +96,7 @@ public class ClothServiceImpl implements ClothService {
     }
 
     // 지난 7일간 착용횟수를 통해 카테고리와 카테고리에 해당하는 옷의 PreView 조회 후 스마트 요약 DTO로 변환해서 반환
+    @Override
     @Transactional(readOnly = true)
     public ClothResponseDTO.SmartSummaryClothPreviewListResult readSmartSummary(Long memberId) {
 
@@ -140,6 +145,7 @@ public class ClothServiceImpl implements ClothService {
         );
     }
 
+    @Override
     @Transactional
     public ClothResponseDTO.ClothCreateResult createCloth(Long memberId,
                                                           ClothRequestDTO.ClothCreateOrUpdateRequest request,
@@ -161,6 +167,7 @@ public class ClothServiceImpl implements ClothService {
         return ClothConverter.toClothCreateResult(cloth);
     }
 
+    @Override
     @Transactional
     public void updateClothById(Long clothId,
                                 ClothRequestDTO.ClothCreateOrUpdateRequest request,
@@ -187,6 +194,7 @@ public class ClothServiceImpl implements ClothService {
         asyncUpdatedClothFromES(existingCloth);
     }
 
+    @Override
     @Transactional
     public void deleteClothById(Long clothId){
         historyClothRepositoryService.deleteAllByClothId(clothId);
@@ -198,6 +206,7 @@ public class ClothServiceImpl implements ClothService {
     }
 
     // 비동기 방식으로 Elasticsearch 수정 요청
+    @Override
     public void asyncUpdatedClothFromES(Cloth cloth) {
         try {
             searchRepositoryService.updateClothDataToElasticsearch(cloth);
@@ -208,6 +217,7 @@ public class ClothServiceImpl implements ClothService {
     }
 
     // 비동기 방식으로 Elasticsearch 삭제 요청
+    @Override
     public void asyncDeletedClothFromES(Long clothId) {
         try {
             searchRepositoryService.deleteClothByIdFromElasticsearch(clothId);

--- a/src/main/java/com/clokey/server/domain/cloth/application/ClothServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/cloth/application/ClothServiceImpl.java
@@ -76,15 +76,19 @@ public class ClothServiceImpl implements ClothService {
 
     // 옷장의 옷의 PreView 조회 후 옷장 조회 DTO로 변환해서 반환
     @Transactional(readOnly = true)
-    public ClothResponseDTO.ClothPreviewListResult readClothPreviewInfoListByClokeyId(
+    public ClothResponseDTO.ClosetViewResult readClothPreviewInfoListByClokeyId(
             String ownerClokeyId, Long requesterId, Long categoryId, Season season, ClothSort sort, int page, int size) {
+
+        String nickname= memberRepositoryService.findByClokeyId(ownerClokeyId).getNickname();
 
         Pageable pageable = PageRequest.of(page-1, size);
         Page<Cloth> clothes = clothRepositoryService.findByClosetFilters(ownerClokeyId, requesterId, categoryId, season, sort, pageable);
 
         List<ClothResponseDTO.ClothPreview> clothPreviews = ClothConverter.toClothPreviewList(clothes);
 
-        return ClothConverter.toClothPreviewListResult(clothes, clothPreviews);
+        ClothResponseDTO.ClothPreviewListResult result = ClothConverter.toClothPreviewListResult(clothes, clothPreviews);
+
+        return ClothConverter.toClosetViewResult(nickname, result);
     }
 
     // 지난 7일간 착용횟수를 통해 카테고리와 카테고리에 해당하는 옷의 PreView 조회 후 스마트 요약 DTO로 변환해서 반환
@@ -93,7 +97,7 @@ public class ClothServiceImpl implements ClothService {
 
         String nickname = memberRepositoryService.findMemberById(memberId).getNickname();
 
-        List<History> histories = historyRepositoryService.findHistoriesByMemberWithinWeek(memberId);
+        List<History> histories = historyRepositoryService.findHistoriesByMemberWithinMonth(memberId);
 
         List<Cloth> clothes = histories.stream()
                 .flatMap(history -> historyClothRepositoryService.findAllClothByHistoryId(history.getId()).stream())

--- a/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
+++ b/src/main/java/com/clokey/server/domain/cloth/converter/ClothConverter.java
@@ -124,6 +124,13 @@ public class ClothConverter {
                 .collect(Collectors.toList());
     }
 
+    public static ClothResponseDTO.ClosetViewResult toClosetViewResult(String nickname, ClothResponseDTO.ClothPreviewListResult result) {
+        return ClothResponseDTO.ClosetViewResult.builder()
+                .nickname(nickname)
+                .clothPreviewListResult(result)
+                .build();
+    }
+
     public static ClothResponseDTO.ClothPreviewListResult toClothPreviewListResult(Page<?> page,
                                                                                    List<ClothResponseDTO.ClothPreview> clothPreviews) {
         return ClothResponseDTO.ClothPreviewListResult.builder()

--- a/src/main/java/com/clokey/server/domain/cloth/domain/repository/ClothImageRepository.java
+++ b/src/main/java/com/clokey/server/domain/cloth/domain/repository/ClothImageRepository.java
@@ -13,6 +13,8 @@ public interface ClothImageRepository extends JpaRepository<ClothImage, Long> {
 
     int deleteByClothId(Long clothId);
 
+    ClothImage findByClothId(Long clothId);
+
     List<ClothImage> findByCloth_IdIn(List<Long> clothIds);
 
     @Modifying

--- a/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
+++ b/src/main/java/com/clokey/server/domain/cloth/dto/ClothResponseDTO.java
@@ -105,6 +105,15 @@ public class ClothResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class ClosetViewResult {
+        private String nickname;
+        private ClothPreviewListResult clothPreviewListResult;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class SmartSummaryClothPreview {
         private String baseCategoryName;
         private String coreCategoryName;

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryService.java
@@ -14,7 +14,7 @@ public interface HistoryRepositoryService {
 
     List<History> findHistoriesByMemberAndYearMonth(Long memberId, String yearMonth);
 
-    List<History> findHistoriesByMemberWithinWeek(Long memberId);
+    List<History> findHistoriesByMemberWithinMonth(Long memberId);
 
     void incrementLikes(Long historyId);
 

--- a/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/history/application/HistoryRepositoryServiceImpl.java
@@ -28,9 +28,9 @@ public class HistoryRepositoryServiceImpl implements HistoryRepositoryService {
     }
 
     @Override
-    public List<History> findHistoriesByMemberWithinWeek(Long memberId) {
-        LocalDate weekAgo = LocalDate.now().minusWeeks(1);
-        return historyRepository.findHistoriesWithinWeek(memberId, weekAgo);
+    public List<History> findHistoriesByMemberWithinMonth(Long memberId) {
+        LocalDate monthAgo = LocalDate.now().minusMonths(1);
+        return historyRepository.findHistoriesWithinMonth(memberId, monthAgo);
     }
 
     @Override

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -20,8 +20,8 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("SELECT h FROM History h WHERE h.member.id = :memberId AND FUNCTION('DATE_FORMAT', h.historyDate, '%Y-%m') = :yearMonth")
     List<History> findHistoriesByMemberAndYearMonth(Long memberId, String yearMonth);
 
-    @Query("SELECT h FROM History h WHERE h.member.id = :memberId AND h.historyDate >= :weekAgo")
-    List<History> findHistoriesWithinWeek(@Param("memberId") Long memberId, @Param("weekAgo") LocalDate weekAgo);
+    @Query("SELECT h FROM History h WHERE h.member.id = :memberId AND h.historyDate >= :monthAgo")
+    List<History> findHistoriesWithinMonth(@Param("memberId") Long memberId, @Param("monthAgo") LocalDate monthAgo);
 
     @Query("UPDATE History h SET h.likes = h.likes + 1 WHERE h.id = :historyId")
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.clokey.server.domain.search.application;
 
+import com.clokey.server.domain.cloth.application.ClothImageRepositoryService;
+import com.clokey.server.domain.cloth.application.ClothImageRepositoryServiceImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +45,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
     private final ElasticsearchClient elasticsearchClient;
 
     private final ClothRepositoryService clothRepositoryService;
+    private final ClothImageRepositoryService clothImageRepositoryService;
     private static final String CLOTH_INDEX_NAME = "cloth";
 
     private final MemberRepositoryService memberRepositoryService;
@@ -63,6 +66,8 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
     private static final String FAILED_ES_DELETE_SYNC_HISTORY_KEY = "failed_es_delete_sync_history";
     private static final String FAILED_ES_UPDATE_SYNC_USER_KEY = "failed_es_update_sync_user";
     private static final String FAILED_ES_DELETE_SYNC_USER_KEY = "failed_es_delete_sync_user";
+    @Autowired
+    private ClothImageRepositoryServiceImpl clothImageRepositoryServiceImpl;
 
     /****************************************Save For Retry Sync****************************************/
 
@@ -101,6 +106,8 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
     @Override
     public void updateClothDataToElasticsearch(Cloth cloth) throws IOException {
 
+        String imageUrl = clothImageRepositoryService.findByClothId(cloth.getId()).getImageUrl();
+
         BulkOperation bulkOperation = BulkOperation.of(op -> op
                 .index(IndexOperation.of(idx -> idx
                         .index(CLOTH_INDEX_NAME)
@@ -109,7 +116,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
                                 .id(cloth.getId())
                                 .name(cloth.getName())
                                 .brand(cloth.getBrand())
-                                .imageUrl(cloth.getImage() != null ? cloth.getImage().getImageUrl() : null)
+                                .imageUrl(imageUrl)
                                 .wearNum(cloth.getWearNum())
                                 .memberId(cloth.getMember().getId())
                                 .visibility(cloth.getVisibility().toString())

--- a/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
@@ -123,7 +123,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
 
         if (bulkResponse.errors()) {
 
-            System.err.println("Elasticsearch 단일 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
+            System.err.println("Elasticsearch 단일 cloth 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
 
             throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
         }
@@ -174,7 +174,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
             );
 
             if (bulkResponse.errors()) {
-                System.err.println("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
+                System.err.println("Elasticsearch cloth 동기화 중 오류 발생: " + bulkResponse.toString());
 
                 throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
             }
@@ -223,7 +223,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
         );
 
         if (bulkResponse.errors()) {
-            System.err.println("Elasticsearch 단일 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
+            System.err.println("Elasticsearch 단일 history 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
 
             throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
         }
@@ -239,7 +239,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
         );
 
         if (!deleteResponse.result().equals(Result.Deleted)) {
-            System.err.println("Elasticsearch에서 clothId: " + historyId + " 에 해당하는 데이터를 찾을 수 없습니다.");
+            System.err.println("Elasticsearch에서 historyId: " + historyId + " 에 해당하는 데이터를 찾을 수 없습니다.");
 
             throw new SearchException(ErrorStatus.ELASTIC_SEARCH_DELETE_FAULT);
         }
@@ -292,7 +292,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
             );
 
             if (bulkResponse.errors()) {
-                System.err.println("Elasticsearch 동기화 중 오류 발생: " + bulkResponse.toString());
+                System.err.println("Elasticsearch history 동기화 중 오류 발생: " + bulkResponse.toString());
 
                 throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
             }
@@ -322,7 +322,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
         );
 
         if (bulkResponse.errors()) {
-            System.err.println("Elasticsearch 단일 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
+            System.err.println("Elasticsearch 단일 member 데이터 업데이트 중 오류 발생: " + bulkResponse.toString());
 
             throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
         }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #310 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 스마트 요약 및 클로젯 API 리팩토링

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 기존의 일주일간의 스마트 요약을 한달간의 스마트요약으로 변경하기 위해 History 불러올 때의 쿼리와 메소드 명 수정
- 옷장 조회에서 닉네임 반환하기 위해 Closet 조회용 DTO 생성
- 이에 따른 컨버터와 서비스단 수정
