### PR TITLE
[refactor/#329] 약관동의 로직수정

### DIFF
--- a/src/main/java/com/clokey/server/domain/term/application/MemberTermRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/term/application/MemberTermRepositoryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.term.domain.entity.MemberTerm;
+import org.springframework.data.repository.query.Param;
 
 
 public interface MemberTermRepositoryService {
@@ -17,4 +18,7 @@ public interface MemberTermRepositoryService {
     MemberTerm save(MemberTerm memberTerm); //// 사용자의 약관 동의 저장
 
     boolean existsByMemberIdAndTermId(Long memberId, Long termId);
+
+    void deleteAllByMemberIdAndTermId(Long memberId, Long termId);
+
 }

--- a/src/main/java/com/clokey/server/domain/term/application/MemberTermRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/term/application/MemberTermRepositoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.clokey.server.domain.term.application;
 
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,5 +42,9 @@ public class MemberTermRepositoryServiceImpl implements MemberTermRepositoryServ
         return memberTermRepository.existsByMemberIdAndTermId(memberId,termId);
     }
 
+    @Override
+    public void deleteAllByMemberIdAndTermId(Long memberId, Long termId){
+        memberTermRepository.deleteAllByMemberIdAndTermId(memberId, termId);
+    }
 
 }

--- a/src/main/java/com/clokey/server/domain/term/application/TermCommandServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/term/application/TermCommandServiceImpl.java
@@ -1,9 +1,11 @@
 package com.clokey.server.domain.term.application;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -19,6 +21,7 @@ import com.clokey.server.domain.term.domain.entity.Term;
 import com.clokey.server.domain.term.dto.TermRequestDTO;
 import com.clokey.server.domain.term.dto.TermResponseDTO;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TermCommandServiceImpl implements TermCommandService {
@@ -29,44 +32,70 @@ public class TermCommandServiceImpl implements TermCommandService {
 
     private static final String APP_VERSION = "1.0.0";
 
-
     @Override
     @Transactional
     public TermResponseDTO joinTerm(Long userId, TermRequestDTO.Join request) {
         // 사용자 조회
         Member member = memberRepositoryService.findMemberById(userId);
 
-        // 약관 처리
+        // 기존 동의 약관 조회
+        List<MemberTerm> existingMemberTerms = memberTermRepositoryService.findByMember(member);
+        Set<Long> existingTermIds = existingMemberTerms.stream()
+                .map(memberTerm -> memberTerm.getTerm().getId())
+                .collect(Collectors.toSet());
+
+        //새로 들어온 약관 동의 목록
+        Set<Long> newTermIds = request.getTerms().stream()
+                .filter(TermRequestDTO.Join.Term::getAgreed)
+                .map(TermRequestDTO.Join.Term::getTermId)
+                .collect(Collectors.toSet());
+
+        // 삭제 대상: 기존에 있었는데 요청에는 없는 약관
+        Set<Long> toDelete = new HashSet<>(existingTermIds);
+        toDelete.removeAll(newTermIds);
+
+        // 추가 대상: 요청에는 있는데 기존에 없던 약관
+        Set<Long> toAdd = new HashSet<>(newTermIds);
+        toAdd.removeAll(existingTermIds);
+
+        // 삭제 처리
+        for (Long termId : toDelete) {
+            memberTermRepositoryService.deleteAllByMemberIdAndTermId(userId, termId);
+        }
+
+        // 추가 처리
         List<TermResponseDTO.Term> termResponses = new ArrayList<>();
-        for (TermRequestDTO.Join.Term termDto : request.getTerms()) {
-            // 약관 조회 (이미 존재 여부는 확인된 상태)
-            Term term = termRepositoryService.findById(termDto.getTermId());
-
-
-            // MemberTerm 생성 및 저장
+        for (Long termId : toAdd) {
+            Term term = termRepositoryService.findById(termId);
             MemberTerm memberTerm = MemberTerm.builder()
                     .member(member)
                     .term(term)
                     .build();
-
             memberTermRepositoryService.save(memberTerm);
 
-            // 응답 데이터에 추가
             termResponses.add(TermResponseDTO.Term.builder()
                     .termId(term.getId())
-                    .agreed(termDto.getAgreed())
+                    .agreed(true)
                     .build());
         }
 
-        if (member.getRegisterStatus() == RegisterStatus.NOT_AGREED) {
-            // 약관 동의가 완료되었으므로 회원의 등록 상태를 업데이트
-            member.updateRegisterStatus(RegisterStatus.AGREED_PROFILE_NOT_SET);
+        // 이미 있던 항목들도 응답에 포함시키기 위해 전체 목록 다시 구성
+        for (Long termId : newTermIds) {
+            if (toAdd.contains(termId)) continue; // 이미 포함됨
+            Term term = termRepositoryService.findById(termId);
+            termResponses.add(TermResponseDTO.Term.builder()
+                    .termId(term.getId())
+                    .agreed(true)
+                    .build());
+        }
 
-            // 저장 (등록 상태 업데이트 반영)
+        // 회원 상태 업데이트
+        if (member.getRegisterStatus() == RegisterStatus.NOT_AGREED) {
+            member.updateRegisterStatus(RegisterStatus.AGREED_PROFILE_NOT_SET);
             memberRepositoryService.saveMember(member);
         }
 
-        // 최종 응답 생성
+        // 최종 응답
         return TermResponseDTO.builder()
                 .userId(userId)
                 .terms(termResponses)
@@ -142,7 +171,7 @@ public class TermCommandServiceImpl implements TermCommandService {
                 memberTermRepositoryService.save(memberTerm);
             } else {
                 // 동의 철회한 경우 -> 삭제
-                memberTermRepositoryService.deleteByMemberIdAndTermId(userId, term.getId());
+                memberTermRepositoryService.deleteAllByMemberIdAndTermId(userId, term.getId());
             }
 
             // 응답 데이터 생성

--- a/src/main/java/com/clokey/server/domain/term/domain/repository/MemberTermRepository.java
+++ b/src/main/java/com/clokey/server/domain/term/domain/repository/MemberTermRepository.java
@@ -6,6 +6,9 @@ import java.util.List;
 
 import com.clokey.server.domain.member.domain.entity.Member;
 import com.clokey.server.domain.term.domain.entity.MemberTerm;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
     void deleteByMemberId(Long memberId);
@@ -17,4 +20,9 @@ public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
     MemberTerm save(MemberTerm memberTerm); // 사용자의 약관 동의 저장
 
     boolean existsByMemberIdAndTermId(Long memberId, Long termId);
+
+    @Modifying
+    @Query("DELETE FROM MemberTerm mt WHERE mt.member.id = :memberId AND mt.term.id = :termId")
+    void deleteAllByMemberIdAndTermId(@Param("memberId") Long memberId, @Param("termId") Long termId);
+
 }

--- a/src/main/java/com/clokey/server/domain/term/exception/validator/EssentialTermAgreeValidator.java
+++ b/src/main/java/com/clokey/server/domain/term/exception/validator/EssentialTermAgreeValidator.java
@@ -1,5 +1,7 @@
 package com.clokey.server.domain.term.exception.validator;
 
+import com.clokey.server.domain.term.application.TermRepositoryService;
+import com.clokey.server.domain.term.domain.entity.Term;
 import org.springframework.stereotype.Component;
 
 import jakarta.validation.ConstraintValidator;
@@ -15,6 +17,8 @@ import com.clokey.server.global.error.code.status.ErrorStatus;
 @RequiredArgsConstructor
 public class EssentialTermAgreeValidator implements ConstraintValidator<EssentialTermAgree, TermRequestDTO.Join> {
 
+    private final TermRepositoryService termRepositoryService;
+
     @Override
     public void initialize(EssentialTermAgree constraintAnnotation) {
         ConstraintValidator.super.initialize(constraintAnnotation);
@@ -28,8 +32,17 @@ public class EssentialTermAgreeValidator implements ConstraintValidator<Essentia
 
         // 필수 약관이 동의되지 않았는지 확인
         boolean allEssentialAgreed = joinRequest.getTerms().stream()
-                .filter(term -> term.getAgreed() != null) // 동의 여부가 null이 아닌 경우에만 체크
-                .allMatch(term -> term.getAgreed() || term.getTermId() == null); // 필수 약관 조건
+                .allMatch(termDto -> {
+                    if (termDto.getTermId() == null) return true;
+
+                    Term term = termRepositoryService.findById(termDto.getTermId());
+
+                    // 필수 약관인데 동의하지 않았다면 실패
+                    if (!term.getOptional() && Boolean.FALSE.equals(termDto.getAgreed())) {
+                        return false;
+                    }
+                    return true;
+                });
 
         if (!allEssentialAgreed) {
             context.disableDefaultConstraintViolation();


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #329 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 기존에는 전체약관의 경우, 최초회원가입시에 1번만 동의 가능했습니다.
- 그런데 프론트측에서 전체약관을 여러번 동의 가능하게 해달라는 요청이 들어왔습니다.
- 기존의 약관재동의 로직은 "만약 내가 전에 4,5번 약관에 동의했는데, 이번에 4번약관만 동의하는걸로 바뀐다면, 5번에 관한 MemberTerm을 삭제한다" 였습니다.
- 그런데 위의 조건은 전체약관을 1번만 동의할 수 있었을때의 기준이라, db에 5번에 관한 MemberTerm이 1개만 있을때를 고려한것이었고, 지금처럼 여러개의 5번 MemberTerm이 존재할시에 그 row 모두를 다 지워야하는 수정사항이 생겨서
- 바꾸었습니다~!! 너무 설명을 못했네요... 궁금한거 있으면 질문해주세요...!

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 
-

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
