### PR TITLE
[fix/#331] 내 자신의 프로필을 조회할 경우 팔로워/팔로잉 목록 조회 가능하도록 수정

### DIFF
--- a/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
+++ b/src/main/java/com/clokey/server/domain/member/api/MemberRestController.java
@@ -91,7 +91,11 @@ public class MemberRestController {
 
     @Operation(summary = "팔로잉/팔로워 목록 조회 API", description = "팔로잉/팔로워 목록을 조회하는 api입니다.")
     @GetMapping("users/{clokeyId}/follow")
-    public BaseResponse<MemberDTO.GetFollowMemberResult> getFollowMembers(@Parameter(name = "user", hidden = true) @AuthUser Member member, @PathVariable("clokeyId") String clokeyId, @RequestParam(value = "page", defaultValue = "1") Integer page, @RequestParam(value = "isFollowing", defaultValue = "true") Boolean isFollowing) {
+    public BaseResponse<MemberDTO.GetFollowMemberResult> getFollowMembers(
+            @Parameter(name = "user", hidden = true) @AuthUser Member member,
+            @PathVariable("clokeyId") String clokeyId,
+            @RequestParam(value = "page", defaultValue = "1") Integer page,
+            @RequestParam(value = "isFollowing", defaultValue = "true") Boolean isFollowing) {
         MemberDTO.GetFollowMemberResult response = memberService.getFollowPeople(member.getId(), clokeyId, page, isFollowing);
         return BaseResponse.onSuccess(SuccessStatus.MEMBER_SUCCESS, response);
     }

--- a/src/main/java/com/clokey/server/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberServiceImpl.java
@@ -216,7 +216,7 @@ public class MemberServiceImpl implements MemberService {
         Member findMember = memberRepositoryService.findByClokeyId(clokeyId);
 
         Pageable pageable = PageRequest.of(page - 1, 10);
-        if (findMember.getVisibility() == Visibility.PUBLIC) {
+        if (findMember.getId().equals(memberId) || findMember.getVisibility() == Visibility.PUBLIC) {
             if (isFollow) {
                 // 팔로잉 리스트 가져오기
                 List<Member> members = followRepositoryService.findFollowingByFollowedId(findMember.getId(), pageable);


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #331 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 내 자신의 프로필을 조회할 경우 팔로워/팔로잉 목록 조회 가능하도록 수정하였습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 비공개 계정인 경우, 자신의 팔로워/팔로잉 목록을 확인할 수 없던 오류를 수정했습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
