### PR TITLE
[fix/#343] ClokeyId를 통한 본인 조회시 정보 넘겨줌

### DIFF
--- a/src/main/java/com/clokey/server/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/MemberServiceImpl.java
@@ -95,7 +95,7 @@ public class MemberServiceImpl implements MemberService {
         Boolean isMyself;
         List<Cloth> topCloths;
 
-        if (clokeyId == null) {
+        if (clokeyId == null || clokeyId.equals(currentUser.getClokeyId())) {
             member = currentUser;
             isFollowing = null;
             isBlocking = null;


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #343 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- ClokeyId를 통한 본인 조회시 정보 넘겨줌

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 원래는 null로 던져주면 본인 조회라고 인식했는데, 검색 경로로 들어갈 경우 ClokeyId를 던져주기 때문에 이 경우 계정이 비공계로 표시될 수 있던 버그를 수정.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
