### PR TITLE
[refactor/#347] hot 계정 로직 수정

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -72,9 +72,19 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("SELECT COUNT(h) FROM History h WHERE h.member = :member")
     Long countHistoryByMember(@Param("member") Member member);
 
-    @Query("SELECT h FROM History h " +
-            "WHERE h.member.id IN :memberIds " +
-            "AND h.createdAt = (SELECT MAX(h2.createdAt) FROM History h2 WHERE h2.member.id = h.member.id AND h2.visibility = 'PUBLIC' AND h2.banned = false) ")
+    @Query("""
+    SELECT h FROM History h
+    WHERE h.member.id IN :memberIds
+      AND h.visibility = 'PUBLIC'
+      AND h.banned = false
+      AND h.createdAt = (
+        SELECT MAX(h2.createdAt)
+        FROM History h2
+        WHERE h2.member.id = h.member.id
+          AND h2.visibility = 'PUBLIC'
+          AND h2.banned = false
+      )
+    """)
     List<History> findHistoryByMemberIdIn(@Param("memberIds") List<Long> memberIds);
 
     @Query("SELECT h FROM History h WHERE h.member.id IN :memberIds " +

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -74,7 +74,7 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
 
     @Query("SELECT h FROM History h " +
             "WHERE h.member.id IN :memberIds " +
-            "AND h.createdAt = (SELECT MAX(h2.createdAt) FROM History h2 WHERE h2.member.id = h.member.id)")
+            "AND h.createdAt = (SELECT MAX(h2.createdAt) FROM History h2 WHERE h2.member.id = h.member.id AND h2.visibility = 'PUBLIC' AND h2.banned = false) ")
     List<History> findHistoryByMemberIdIn(@Param("memberIds") List<Long> memberIds);
 
     @Query("SELECT h FROM History h WHERE h.member.id IN :memberIds " +

--- a/src/main/java/com/clokey/server/domain/member/application/FollowRepositoryService.java
+++ b/src/main/java/com/clokey/server/domain/member/application/FollowRepositoryService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.clokey.server.domain.member.domain.entity.Follow;
 import com.clokey.server.domain.member.domain.entity.Member;
@@ -39,5 +40,5 @@ public interface FollowRepositoryService {
 
     List<Member> findFollowingByFollowedId(Long followedId, Pageable pageable);
 
-    List<Long> findTopFollowingMembers();
+    List<Long> findTopFollowingMembers(Set<Long> blockingMemberIds, Member member);
 }

--- a/src/main/java/com/clokey/server/domain/member/application/FollowRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/FollowRepositoryServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 
@@ -105,7 +106,7 @@ public class FollowRepositoryServiceImpl implements FollowRepositoryService {
     }
 
     @Override
-    public List<Long> findTopFollowingMembers() {
-        return followRepository.findTopFollowingMembers(PageRequest.of(0, 5));
+    public List<Long> findTopFollowingMembers(Set<Long> blockingMemberIds, Member member) {
+        return followRepository.findTopFollowingMembers(blockingMemberIds, member.getId(), PageRequest.of(0, 4));
     }
 }

--- a/src/main/java/com/clokey/server/domain/member/domain/repository/FollowRepository.java
+++ b/src/main/java/com/clokey/server/domain/member/domain/repository/FollowRepository.java
@@ -64,6 +64,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
         SELECT 1 FROM History h
         WHERE h.member.id = f.following.id
           AND h.visibility = 'PUBLIC'
+          AND h.banned = false
       )
     GROUP BY f.following.id
     ORDER BY COUNT(f.followed.id) DESC

--- a/src/main/java/com/clokey/server/domain/member/domain/repository/FollowRepository.java
+++ b/src/main/java/com/clokey/server/domain/member/domain/repository/FollowRepository.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.clokey.server.domain.member.domain.entity.Follow;
 import com.clokey.server.domain.member.domain.entity.Member;
@@ -53,8 +54,19 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Query("SELECT f.following FROM Follow f WHERE f.followed.id = :followedId")
     List<Member> findFollowingByFollowedId(@Param("followedId") Long followedId, Pageable pageable);
 
-    @Query("SELECT f.following.id FROM Follow f " +
-            "GROUP BY f.following.id " +
-            "ORDER BY COUNT(f.followed.id) DESC")
-    List<Long> findTopFollowingMembers(Pageable pageable);
+    @Query("""
+    SELECT f.following.id FROM Follow f
+    WHERE f.following.id NOT IN :blockingMemberIds
+      AND f.following.id <> :memberId
+      AND f.following.banned = false
+      AND f.following.visibility = 'PUBLIC'
+      AND EXISTS (
+        SELECT 1 FROM History h
+        WHERE h.member.id = f.following.id
+          AND h.visibility = 'PUBLIC'
+      )
+    GROUP BY f.following.id
+    ORDER BY COUNT(f.followed.id) DESC
+    """)
+    List<Long> findTopFollowingMembers(Set<Long> blockingMemberIds, Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/recommendation/application/RecommendationServiceImpl.java
@@ -305,7 +305,7 @@ public class RecommendationServiceImpl implements RecommendationService {
     }
 
     private List<RecommendationResponseDTO.PeopleCacheResult> getPeopleList(Member member, Set<Long> blockingMembers) {
-        List<Long> topFollowingMemberIds = followRepositoryService.findTopFollowingMembers();
+        List<Long> topFollowingMemberIds = followRepositoryService.findTopFollowingMembers(blockingMembers, member);
 
         if (topFollowingMemberIds.isEmpty()) {
             return List.of();
@@ -316,33 +316,13 @@ public class RecommendationServiceImpl implements RecommendationService {
         if (recommendedMemberHistories.isEmpty()) {
             return List.of();
         }
-
-        Map<Long, History> historyMap = recommendedMemberHistories.stream()
-                .collect(Collectors.toMap(
-                        h -> h.getMember().getId(),
-                        h -> h,
-                        (h1, h2) -> h1.getCreatedAt().isAfter(h2.getCreatedAt()) ? h1 : h2
-                ));
-
-        List<History> filteredHistories = topFollowingMemberIds.stream()
-                .map(historyMap::get)
-                .filter(Objects::nonNull)
-                .filter(history -> history.getMember().getVisibility() == Visibility.PUBLIC &&
-                        history.getVisibility() == Visibility.PUBLIC && history.getMember() != member && !blockingMembers.contains(history.getMember().getId()))
-                .limit(4)
-                .toList();
-
-        if (filteredHistories.isEmpty()) {
-            return List.of();
-        }
-
-        List<Long> historyIds = filteredHistories.stream()
+        List<Long> historyIds = recommendedMemberHistories.stream()
                 .map(History::getId)
                 .toList();
 
         Map<Long, String> historyImageMap = historyImageRepositoryService.findFirstImagesByHistoryIds(historyIds);
 
-        return RecommendationConverter.toPeopleCacheDTO(filteredHistories, historyImageMap);
+        return RecommendationConverter.toPeopleCacheDTO(recommendedMemberHistories, historyImageMap);
     }
 
 


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #347 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
hot 계정 로직 수정

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- hot 계정 반환은 계정을 찾기 -> 계정의 history 찾기 -> history의 이미지 찾기 과정입니다.

- 계정 찾기의 쿼리는 가장 팔로워 수 많은 member 객체 반환하는데, 조건은 다음과 같습니다.
 1. 해당 계정이 history 존재 (history는 public, banned = false)
 2. public이면서 유저 자신이 아니고, 유저가 차단한 사람이 아님

`@Query("""
    SELECT f.following.id FROM Follow f
    WHERE f.following.id NOT IN :blockingMemberIds
      AND f.following.id <> :memberId
      AND f.following.banned = false
      AND f.following.visibility = 'PUBLIC'
      AND EXISTS (
        SELECT 1 FROM History h
        WHERE h.member.id = f.following.id
          AND h.visibility = 'PUBLIC'
          AND h.banned = false
      )
    GROUP BY f.following.id
    ORDER BY COUNT(f.followed.id) DESC
    """)`


- history 쿼리는 다음과 같습니다.
 1. history가 public
 2. banned = false
인 것들 중 가장 최근의 history 반환
 
`@Query("""
    SELECT h FROM History h
    WHERE h.member.id IN :memberIds
      AND h.visibility = 'PUBLIC'
      AND h.banned = false
      AND h.createdAt = (
        SELECT MAX(h2.createdAt)
        FROM History h2
        WHERE h2.member.id = h.member.id
          AND h2.visibility = 'PUBLIC'
          AND h2.banned = false
      )
    """)`

- 기존 service의 필터링 로직 제거하였습니다.

## 📸 스크린샷
<!-- 작업한 화면의 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/9f176bad-1ac7-4bc8-a36a-8a37299b867d)


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
