### PR TITLE
[fix/#359] Elastic Search 복구 및 보안설정

### DIFF
--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryClothRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryClothRepository.java
@@ -50,4 +50,7 @@ public interface HistoryClothRepository extends JpaRepository<HistoryCloth, Long
     boolean existsByHistoryIdAndClothId(Long historyId, Long clothId);
     boolean existsByHistoryId(Long historyId);
 
+    // fetch join으로 카테고리 포함하여 미리 다 조회
+    @Query("SELECT hc.cloth FROM HistoryCloth hc JOIN FETCH hc.cloth.category WHERE hc.history.id = :historyId")
+    List<Cloth> findAllClothsWithCategoryByHistoryId(@Param("historyId") Long historyId);
 }

--- a/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/com/clokey/server/domain/history/domain/repository/HistoryRepository.java
@@ -100,4 +100,8 @@ public interface HistoryRepository extends JpaRepository<History, Long>,HistoryP
 
     @Query("SELECT h FROM History h JOIN FETCH h.member WHERE h.id = :id")
     Optional<History> findByIdWithWriter(@Param("id") Long id);
+
+    // fetch join으로 옷 포함하여 미리 다 조회
+    @Query("SELECT h FROM History h JOIN FETCH h.member")
+    List<History> findAllWithMember();
 }

--- a/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
@@ -128,6 +128,13 @@ public class AuthServiceImpl implements AuthService {
                 // DB에 사용자 정보가 없으면 회원가입
                 member = Member.builder().kakaoId(kakaoUser.getId()).nickname(kakaoUser.getKakaoAccount().getProfile().getNickname()).email(kakaoUser.getKakaoAccount().getEmail()).registerStatus(RegisterStatus.NOT_AGREED).socialType(SocialType.KAKAO).deviceToken(deviceToken).build();
                 memberRepositoryService.saveMember(member);
+
+                // 회원가입 시, ES 동기화
+                try {
+                    searchRepositoryService.updateMemberDataToElasticsearch(member);
+                } catch (IOException e) {
+                    throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+                }
             }
 
             member.updateDeviceToken(deviceToken);
@@ -137,6 +144,13 @@ public class AuthServiceImpl implements AuthService {
             // DB에 사용자 정보가 없으면 회원가입
             member = Member.builder().kakaoId(kakaoUser.getId()).nickname(kakaoUser.getKakaoAccount().getProfile().getNickname()).email(kakaoUser.getKakaoAccount().getEmail()).registerStatus(RegisterStatus.NOT_AGREED).socialType(SocialType.KAKAO).deviceToken(deviceToken).build();
             memberRepositoryService.saveMember(member);
+
+            // 회원가입 시, ES 동기화
+            try {
+                searchRepositoryService.updateMemberDataToElasticsearch(member);
+            } catch (IOException e) {
+                throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+            }
         }
 
         String accessToken = generateAccessToken(member.getId(), member.getEmail());
@@ -144,13 +158,6 @@ public class AuthServiceImpl implements AuthService {
 
         member.updateToken(accessToken, refreshToken);
         memberRepositoryService.saveMember(member);
-
-        // ES 동기화
-        try {
-            searchRepositoryService.updateMemberDataToElasticsearch(member);
-        } catch (IOException e) {
-            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
-        }
 
         // 토큰 반환
         AuthDTO.TokenResponse tokenResponse=AuthDTO.TokenResponse.builder()
@@ -373,6 +380,13 @@ public class AuthServiceImpl implements AuthService {
             if(member.getSocialType()!=SocialType.APPLE){
                 member = Member.builder().email(email).socialType(SocialType.APPLE).registerStatus(RegisterStatus.NOT_AGREED).deviceToken(deviceToken).build();
                 memberRepositoryService.saveMember(member);
+
+                // 회원가입 시, ES 동기화
+                try {
+                    searchRepositoryService.updateMemberDataToElasticsearch(member);
+                } catch (IOException e) {
+                    throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+                }
             }
 
             member.updateDeviceToken(deviceToken);
@@ -381,6 +395,13 @@ public class AuthServiceImpl implements AuthService {
         } else {
             member = Member.builder().email(email).socialType(SocialType.APPLE).registerStatus(RegisterStatus.NOT_AGREED).deviceToken(deviceToken).build();
             memberRepositoryService.saveMember(member);
+
+            // 회원가입 시, ES 동기화
+            try {
+                searchRepositoryService.updateMemberDataToElasticsearch(member);
+            } catch (IOException e) {
+                throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
+            }
         }
 
         // 토큰 생성
@@ -389,13 +410,6 @@ public class AuthServiceImpl implements AuthService {
 
         member.updateToken(jwtAccessToken, jwtRefreshToken);
         memberRepositoryService.saveMember(member);
-
-        // ES 동기화
-        try {
-            searchRepositoryService.updateMemberDataToElasticsearch(member);
-        } catch (IOException e) {
-            throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
-        }
 
         // 응답 반환
          AuthDTO.TokenResponse tokenResponse=AuthDTO.TokenResponse.builder()

--- a/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/member/application/AuthServiceImpl.java
@@ -125,16 +125,9 @@ public class AuthServiceImpl implements AuthService {
             }
 
             if(member.getSocialType()!=SocialType.KAKAO){
-                // DB에 사용자 정보가 없으면 회원가입
+                // 기존 가입했던 데이터로 카카오 회원가입
                 member = Member.builder().kakaoId(kakaoUser.getId()).nickname(kakaoUser.getKakaoAccount().getProfile().getNickname()).email(kakaoUser.getKakaoAccount().getEmail()).registerStatus(RegisterStatus.NOT_AGREED).socialType(SocialType.KAKAO).deviceToken(deviceToken).build();
                 memberRepositoryService.saveMember(member);
-
-                // 회원가입 시, ES 동기화
-                try {
-                    searchRepositoryService.updateMemberDataToElasticsearch(member);
-                } catch (IOException e) {
-                    throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
-                }
             }
 
             member.updateDeviceToken(deviceToken);
@@ -378,15 +371,9 @@ public class AuthServiceImpl implements AuthService {
             }
 
             if(member.getSocialType()!=SocialType.APPLE){
+                // 기존 가입했던 데이터로 애플 회원가입
                 member = Member.builder().email(email).socialType(SocialType.APPLE).registerStatus(RegisterStatus.NOT_AGREED).deviceToken(deviceToken).build();
                 memberRepositoryService.saveMember(member);
-
-                // 회원가입 시, ES 동기화
-                try {
-                    searchRepositoryService.updateMemberDataToElasticsearch(member);
-                } catch (IOException e) {
-                    throw new SearchException(ErrorStatus.ELASTIC_SEARCH_SYNC_FAULT);
-                }
             }
 
             member.updateDeviceToken(deviceToken);

--- a/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
+++ b/src/main/java/com/clokey/server/domain/search/application/SearchRepositoryServiceImpl.java
@@ -195,7 +195,7 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
 
         List<String> hashtagNames = hashtagHistoryRepository.findHashtagNamesByHistoryId(history.getId());
 
-        List<Cloth> clothes = historyClothRepository.findAllClothsByHistoryId(history.getId());
+        List<Cloth> clothes = historyClothRepository.findAllClothsWithCategoryByHistoryId(history.getId());
 
         List<String> categoryNames = clothes.stream()
                 .map(cloth -> cloth.getCategory().getName())
@@ -254,14 +254,14 @@ public class SearchRepositoryServiceImpl implements SearchRepositoryService {
     // JPA에서 모든 History 데이터 가져와서 Elasticsearch로 저장하는 메서드
     @Override
     public void syncAllHistoriesDataToElasticsearch() throws IOException {
-        List<History> historyList = historyRepository.findAll();
+        List<History> historyList = historyRepository.findAllWithMember();
 
         List<BulkOperation> bulkOperations = historyList.stream()
                 .map(history -> {
 
                     List<String> hashtagNames = hashtagHistoryRepository.findHashtagNamesByHistoryId(history.getId());
 
-                    List<Cloth> clothes = historyClothRepository.findAllClothsByHistoryId(history.getId());
+                    List<Cloth> clothes = historyClothRepository.findAllClothsWithCategoryByHistoryId(history.getId());
 
                     List<String> categoryNames = clothes.stream()
                             .map(cloth -> cloth.getCategory().getName())


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #359 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- Elastic Search 복구 및 보안설정
- 일부 동기화 로직 수정

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- AWS 설정
1. Elastic Search EC2가 보안그룹을 통해 VPC 내에서만 동작하도록 허용
2. 배포된 EC2와 private IP를 통해서 통신함
3. 이에 맞게 secret.yml 수정
- Spring 코드 수정
1. 기록 동기화 시, lazy 로딩 방지
2. 회원가입이 아닌 login 시에 ES 업데이트 하지 않도록 로직 수정 

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- Elastic Search 인덱스 등은 복구가 되었으나 EC2 내에서 통신 장애가 있는 것 같아 확인해봐야합니다. 데이터 복구 등은 마쳤어요.
